### PR TITLE
chore: rename module to `charm.land/fantasy`

### DIFF
--- a/anthropic/anthropic.go
+++ b/anthropic/anthropic.go
@@ -11,12 +11,12 @@ import (
 	"maps"
 	"strings"
 
+	"charm.land/fantasy/ai"
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/anthropics/anthropic-sdk-go/bedrock"
 	"github.com/anthropics/anthropic-sdk-go/option"
 	"github.com/anthropics/anthropic-sdk-go/packages/param"
 	"github.com/anthropics/anthropic-sdk-go/vertex"
-	"github.com/charmbracelet/fantasy/ai"
 	"golang.org/x/oauth2/google"
 )
 

--- a/anthropic/provider_options.go
+++ b/anthropic/provider_options.go
@@ -1,6 +1,6 @@
 package anthropic
 
-import "github.com/charmbracelet/fantasy/ai"
+import "charm.land/fantasy/ai"
 
 type ProviderOptions struct {
 	SendReasoning          *bool                   `json:"send_reasoning"`

--- a/azure/azure.go
+++ b/azure/azure.go
@@ -1,8 +1,8 @@
 package azure
 
 import (
-	"github.com/charmbracelet/fantasy/ai"
-	"github.com/charmbracelet/fantasy/openaicompat"
+	"charm.land/fantasy/ai"
+	"charm.land/fantasy/openaicompat"
 	"github.com/openai/openai-go/v2/azure"
 	"github.com/openai/openai-go/v2/option"
 )

--- a/bedrock/bedrock.go
+++ b/bedrock/bedrock.go
@@ -1,9 +1,9 @@
 package bedrock
 
 import (
+	"charm.land/fantasy/ai"
+	"charm.land/fantasy/anthropic"
 	"github.com/anthropics/anthropic-sdk-go/option"
-	"github.com/charmbracelet/fantasy/ai"
-	"github.com/charmbracelet/fantasy/anthropic"
 )
 
 type options struct {

--- a/examples/agent/main.go
+++ b/examples/agent/main.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/charmbracelet/fantasy/ai"
-	"github.com/charmbracelet/fantasy/openrouter"
+	"charm.land/fantasy/ai"
+	"charm.land/fantasy/openrouter"
 )
 
 func main() {

--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/charmbracelet/fantasy/ai"
-	"github.com/charmbracelet/fantasy/anthropic"
+	"charm.land/fantasy/ai"
+	"charm.land/fantasy/anthropic"
 )
 
 func main() {

--- a/examples/stream/main.go
+++ b/examples/stream/main.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/charmbracelet/fantasy/ai"
-	"github.com/charmbracelet/fantasy/openai"
+	"charm.land/fantasy/ai"
+	"charm.land/fantasy/openai"
 )
 
 func main() {

--- a/examples/streaming-agent-simple/main.go
+++ b/examples/streaming-agent-simple/main.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/charmbracelet/fantasy/ai"
-	"github.com/charmbracelet/fantasy/openai"
+	"charm.land/fantasy/ai"
+	"charm.land/fantasy/openai"
 )
 
 func main() {

--- a/examples/streaming-agent/main.go
+++ b/examples/streaming-agent/main.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/charmbracelet/fantasy/ai"
-	"github.com/charmbracelet/fantasy/anthropic"
+	"charm.land/fantasy/ai"
+	"charm.land/fantasy/anthropic"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/charmbracelet/fantasy
+module charm.land/fantasy
 
 go 1.24.5
 

--- a/google/google.go
+++ b/google/google.go
@@ -11,9 +11,9 @@ import (
 	"net/http"
 	"strings"
 
+	"charm.land/fantasy/ai"
+	"charm.land/fantasy/anthropic"
 	"cloud.google.com/go/auth"
-	"github.com/charmbracelet/fantasy/ai"
-	"github.com/charmbracelet/fantasy/anthropic"
 	"github.com/charmbracelet/x/exp/slice"
 	"github.com/google/uuid"
 	"google.golang.org/genai"

--- a/google/provider_options.go
+++ b/google/provider_options.go
@@ -1,6 +1,6 @@
 package google
 
-import "github.com/charmbracelet/fantasy/ai"
+import "charm.land/fantasy/ai"
 
 type ThinkingConfig struct {
 	ThinkingBudget  *int64 `json:"thinking_budget"`

--- a/openai/language_model.go
+++ b/openai/language_model.go
@@ -9,7 +9,7 @@ import (
 	"io"
 	"strings"
 
-	"github.com/charmbracelet/fantasy/ai"
+	"charm.land/fantasy/ai"
 	xjson "github.com/charmbracelet/x/json"
 	"github.com/google/uuid"
 	"github.com/openai/openai-go/v2"

--- a/openai/language_model_hooks.go
+++ b/openai/language_model_hooks.go
@@ -3,7 +3,7 @@ package openai
 import (
 	"fmt"
 
-	"github.com/charmbracelet/fantasy/ai"
+	"charm.land/fantasy/ai"
 	"github.com/openai/openai-go/v2"
 	"github.com/openai/openai-go/v2/packages/param"
 	"github.com/openai/openai-go/v2/shared"

--- a/openai/openai.go
+++ b/openai/openai.go
@@ -5,7 +5,7 @@ import (
 	"cmp"
 	"maps"
 
-	"github.com/charmbracelet/fantasy/ai"
+	"charm.land/fantasy/ai"
 	"github.com/openai/openai-go/v2"
 	"github.com/openai/openai-go/v2/option"
 )

--- a/openai/openai_test.go
+++ b/openai/openai_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/charmbracelet/fantasy/ai"
+	"charm.land/fantasy/ai"
 	"github.com/openai/openai-go/v2/packages/param"
 	"github.com/stretchr/testify/require"
 )

--- a/openai/provider_options.go
+++ b/openai/provider_options.go
@@ -1,7 +1,7 @@
 package openai
 
 import (
-	"github.com/charmbracelet/fantasy/ai"
+	"charm.land/fantasy/ai"
 	"github.com/openai/openai-go/v2"
 )
 

--- a/openai/responses_language_model.go
+++ b/openai/responses_language_model.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/charmbracelet/fantasy/ai"
+	"charm.land/fantasy/ai"
 	"github.com/google/uuid"
 	"github.com/openai/openai-go/v2"
 	"github.com/openai/openai-go/v2/packages/param"

--- a/openai/responses_options.go
+++ b/openai/responses_options.go
@@ -3,7 +3,7 @@ package openai
 import (
 	"slices"
 
-	"github.com/charmbracelet/fantasy/ai"
+	"charm.land/fantasy/ai"
 )
 
 type ResponsesReasoningMetadata struct {

--- a/openaicompat/language_model_hooks.go
+++ b/openaicompat/language_model_hooks.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/charmbracelet/fantasy/ai"
-	"github.com/charmbracelet/fantasy/openai"
+	"charm.land/fantasy/ai"
+	"charm.land/fantasy/openai"
 	openaisdk "github.com/openai/openai-go/v2"
 	"github.com/openai/openai-go/v2/packages/param"
 	"github.com/openai/openai-go/v2/shared"

--- a/openaicompat/openaicompat.go
+++ b/openaicompat/openaicompat.go
@@ -1,8 +1,8 @@
 package openaicompat
 
 import (
-	"github.com/charmbracelet/fantasy/ai"
-	"github.com/charmbracelet/fantasy/openai"
+	"charm.land/fantasy/ai"
+	"charm.land/fantasy/openai"
 	"github.com/openai/openai-go/v2/option"
 )
 

--- a/openaicompat/provider_options.go
+++ b/openaicompat/provider_options.go
@@ -1,8 +1,8 @@
 package openaicompat
 
 import (
-	"github.com/charmbracelet/fantasy/ai"
-	"github.com/charmbracelet/fantasy/openai"
+	"charm.land/fantasy/ai"
+	"charm.land/fantasy/openai"
 )
 
 type ProviderOptions struct {

--- a/openrouter/language_model_hooks.go
+++ b/openrouter/language_model_hooks.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"maps"
 
-	"github.com/charmbracelet/fantasy/ai"
-	"github.com/charmbracelet/fantasy/anthropic"
+	"charm.land/fantasy/ai"
+	"charm.land/fantasy/anthropic"
 	openaisdk "github.com/openai/openai-go/v2"
 	"github.com/openai/openai-go/v2/packages/param"
 )

--- a/openrouter/openrouter.go
+++ b/openrouter/openrouter.go
@@ -3,8 +3,8 @@ package openrouter
 import (
 	"encoding/json"
 
-	"github.com/charmbracelet/fantasy/ai"
-	"github.com/charmbracelet/fantasy/openai"
+	"charm.land/fantasy/ai"
+	"charm.land/fantasy/openai"
 	"github.com/openai/openai-go/v2/option"
 )
 

--- a/openrouter/provider_options.go
+++ b/openrouter/provider_options.go
@@ -1,7 +1,7 @@
 package openrouter
 
 import (
-	"github.com/charmbracelet/fantasy/ai"
+	"charm.land/fantasy/ai"
 )
 
 type ReasoningEffort string

--- a/providertests/anthropic_test.go
+++ b/providertests/anthropic_test.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/charmbracelet/fantasy/ai"
-	"github.com/charmbracelet/fantasy/anthropic"
+	"charm.land/fantasy/ai"
+	"charm.land/fantasy/anthropic"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/dnaeon/go-vcr.v4/pkg/recorder"
 )

--- a/providertests/azure_test.go
+++ b/providertests/azure_test.go
@@ -6,9 +6,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/charmbracelet/fantasy/ai"
-	"github.com/charmbracelet/fantasy/azure"
-	"github.com/charmbracelet/fantasy/openai"
+	"charm.land/fantasy/ai"
+	"charm.land/fantasy/azure"
+	"charm.land/fantasy/openai"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/dnaeon/go-vcr.v4/pkg/recorder"
 )

--- a/providertests/bedrock_test.go
+++ b/providertests/bedrock_test.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/charmbracelet/fantasy/ai"
-	"github.com/charmbracelet/fantasy/bedrock"
+	"charm.land/fantasy/ai"
+	"charm.land/fantasy/bedrock"
 	"gopkg.in/dnaeon/go-vcr.v4/pkg/recorder"
 )
 

--- a/providertests/common_test.go
+++ b/providertests/common_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/charmbracelet/fantasy/ai"
+	"charm.land/fantasy/ai"
 	"github.com/joho/godotenv"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/dnaeon/go-vcr.v4/pkg/recorder"

--- a/providertests/google_test.go
+++ b/providertests/google_test.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/charmbracelet/fantasy/ai"
-	"github.com/charmbracelet/fantasy/google"
+	"charm.land/fantasy/ai"
+	"charm.land/fantasy/google"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/dnaeon/go-vcr.v4/pkg/recorder"
 )

--- a/providertests/openai_responses_test.go
+++ b/providertests/openai_responses_test.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/charmbracelet/fantasy/ai"
-	"github.com/charmbracelet/fantasy/openai"
+	"charm.land/fantasy/ai"
+	"charm.land/fantasy/openai"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/dnaeon/go-vcr.v4/pkg/recorder"
 )

--- a/providertests/openai_test.go
+++ b/providertests/openai_test.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/charmbracelet/fantasy/ai"
-	"github.com/charmbracelet/fantasy/openai"
+	"charm.land/fantasy/ai"
+	"charm.land/fantasy/openai"
 	"gopkg.in/dnaeon/go-vcr.v4/pkg/recorder"
 )
 

--- a/providertests/openaicompat_test.go
+++ b/providertests/openaicompat_test.go
@@ -5,9 +5,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/charmbracelet/fantasy/ai"
-	"github.com/charmbracelet/fantasy/openai"
-	"github.com/charmbracelet/fantasy/openaicompat"
+	"charm.land/fantasy/ai"
+	"charm.land/fantasy/openai"
+	"charm.land/fantasy/openaicompat"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/dnaeon/go-vcr.v4/pkg/recorder"
 )

--- a/providertests/openrouter_test.go
+++ b/providertests/openrouter_test.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/charmbracelet/fantasy/ai"
-	"github.com/charmbracelet/fantasy/openrouter"
+	"charm.land/fantasy/ai"
+	"charm.land/fantasy/openrouter"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/dnaeon/go-vcr.v4/pkg/recorder"
 )


### PR DESCRIPTION
In preparation for the vanity domain migration. We'll still need to setup this on the website side.
