### PR TITLE
feat: Add ExtraFields support to OpenAI providers for custom parameters

### DIFF
--- a/providers/openai/language_model_hooks.go
+++ b/providers/openai/language_model_hooks.go
@@ -99,6 +99,11 @@ func DefaultPrepareCallFunc(model fantasy.LanguageModel, params *openai.ChatComp
 		}
 		params.Metadata = metadata
 	}
+
+	// Apply extra fields for custom OpenAI-compatible APIs (e.g., Z.AI GLM thinking mode)
+	if providerOptions.ExtraFields != nil && len(providerOptions.ExtraFields) > 0 {
+		params.SetExtraFields(providerOptions.ExtraFields)
+	}
 	if providerOptions.PromptCacheKey != nil {
 		params.PromptCacheKey = param.NewOpt(*providerOptions.PromptCacheKey)
 	}

--- a/providers/openai/provider_options.go
+++ b/providers/openai/provider_options.go
@@ -47,6 +47,9 @@ type ProviderOptions struct {
 	SafetyIdentifier    *string          `json:"safety_identifier"`
 	ServiceTier         *string          `json:"service_tier"`
 	StructuredOutputs   *bool            `json:"structured_outputs"`
+	// ExtraFields allows passing arbitrary additional parameters to OpenAI-compatible APIs
+	// that require custom fields not part of the standard OpenAI API specification.
+	ExtraFields map[string]any `json:"extra_fields,omitempty"`
 }
 
 // Options implements the ProviderOptions interface.

--- a/providers/openaicompat/language_model_hooks.go
+++ b/providers/openaicompat/language_model_hooks.go
@@ -41,6 +41,12 @@ func PrepareCallFunc(_ fantasy.LanguageModel, params *openaisdk.ChatCompletionNe
 	if providerOptions.User != nil {
 		params.User = param.NewOpt(*providerOptions.User)
 	}
+
+	// Apply extra fields for custom OpenAI-compatible APIs (e.g., Z.AI GLM thinking mode)
+	if providerOptions.ExtraFields != nil && len(providerOptions.ExtraFields) > 0 {
+		params.SetExtraFields(providerOptions.ExtraFields)
+	}
+
 	return nil, nil
 }
 

--- a/providers/openaicompat/provider_options.go
+++ b/providers/openaicompat/provider_options.go
@@ -10,6 +10,9 @@ import (
 type ProviderOptions struct {
 	User            *string                 `json:"user"`
 	ReasoningEffort *openai.ReasoningEffort `json:"reasoning_effort"`
+	// ExtraFields allows passing arbitrary additional parameters to custom OpenAI-compatible APIs
+	// that require custom fields not part of the standard OpenAI API specification.
+	ExtraFields map[string]any `json:"extra_fields,omitempty"`
 }
 
 // ReasoningData represents reasoning data for OpenAI-compatible provider.


### PR DESCRIPTION
Adds support for arbitrary extra fields in OpenAI and OpenAI-compatible providers to enable custom parameters required by OpenAI-compatible APIs like Z.AI GLM.

The OpenAI Go SDK's ChatCompletionNewParams provides a SetExtraFields() method, but Fantasy had no way to utilize it. This change adds an ExtraFields field to ProviderOptions and calls SetExtraFields() when extra fields are present.

Use case:
Custom OpenAI-compatible APIs (like Z.AI GLM) require additional parameters such as thinking mode configuration that aren't part of OpenAI's API spec:

```json
{
  "extra_fields": {
    "thinking": {
      "budget_tokens": 26214,
      "type": "enabled"
    }
  }
}
```

Changes:
- Add \`ExtraFields map[string]any\` field to ProviderOptions in both openai and openaicompat providers
- Call \`params.SetExtraFields()\` in PrepareCallFunc when ExtraFields present
- Minimal, non-breaking change using omitempty JSON tag

This enables Crush (charmbracelet/crush#1171) and other Fantasy consumers to pass custom parameters to OpenAI-compatible APIs without modifying Fantasy for each specific API's custom fields.

Tested: Build successful, no breaking changes to existing functionality.

- [ ] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
