### PR TITLE
fix: run tools in order

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -676,7 +676,6 @@ func (a *agent) executeTools(ctx context.Context, allTools []AgentTool, toolCall
 				ClientMetadata:   toolResult.Metadata,
 				ProviderExecuted: false,
 			}
-			results = append(results, result)
 			if toolResultCallback != nil {
 				if cbErr := toolResultCallback(result); cbErr != nil {
 					return nil, cbErr


### PR DESCRIPTION
this is causing issues with crush so we need to make them run one after another.