### PR TITLE
Fix context variable name in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ agent := fantasy.NewAgent(model, fantasy.WithTools(cuteDogTool))
 
 // Put that agent to work!
 const prompt = "Find all the cute dogs in Silver Lake, Los Angeles."
-result, err := agent.Generate(context.Background(), fantasy.AgentCall{Prompt: prompt})
+result, err := agent.Generate(ctx, fantasy.AgentCall{Prompt: prompt})
 if err != nil {
     fmt.Fprintln(os.Stderr, "Oof:", err)
     os.Exit(1)


### PR DESCRIPTION
Just spotted it while reading the README.

- [ ] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).