### PR TITLE
feat(openai): add OnRawResponse hook for custom content pre-processing

### DIFF
--- a/providers/openai/language_model_hooks.go
+++ b/providers/openai/language_model_hooks.go
@@ -35,6 +35,10 @@ type LanguageModelStreamProviderMetadataFunc = func(choice openai.ChatCompletion
 // LanguageModelToPromptFunc is a function that handles converting fantasy prompts to openai sdk messages.
 type LanguageModelToPromptFunc = func(prompt fantasy.Prompt, provider, model string) ([]openai.ChatCompletionMessageParamUnion, []fantasy.CallWarning)
 
+// LanguageModelOnRawResponseFunc is a function that processes raw response content before parsing.
+// This allows custom pre-processing of LLM responses, such as converting non-standard tool call formats.
+type LanguageModelOnRawResponseFunc = func(content string) (string, error)
+
 // DefaultPrepareCallFunc is the default implementation for preparing a call to the language model.
 func DefaultPrepareCallFunc(model fantasy.LanguageModel, params *openai.ChatCompletionNewParams, call fantasy.Call) ([]fantasy.CallWarning, error) {
 	if call.ProviderOptions == nil {


### PR DESCRIPTION
Add LanguageModelOnRawResponseFunc hook that is called before parsing response content. This allows custom pre-processing of LLM responses.

**Use case:**
Some LLMs (like Qwen3-Coder) occasionally generate tool calls in XML format instead of JSON. This hook allows converting XML to JSON before Fantasy parses the response.

**Example:**
```go
provider, err := openaicompat.New(
    openaicompat.WithBaseURL("http://localhost:8080/v1"),
    openaicompat.WithAPIKey("key"),
    openaicompat.WithLanguageModelOptions(
        openai.WithLanguageModelOnRawResponseFunc(func(content string) (string, error) {
            if xmltool.HasXMLToolCalls(content) {
                return xmltool.ConvertToJSON(content)
            }
            return content, nil
        }),
    ),
)
```

**Benefits:**
- Flexibility for custom pre-processing
- Support for non-standard tool call formats
- Debugging capabilities
- Handle provider-specific quirks

- [ ] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
