### PR TITLE
fix: look for gpt model type in any part of ID

### DIFF
--- a/providers/openai/language_model.go
+++ b/providers/openai/language_model.go
@@ -557,7 +557,11 @@ func (o languageModel) Stream(ctx context.Context, call fantasy.Call) (fantasy.S
 }
 
 func isReasoningModel(modelID string) bool {
-	return strings.HasPrefix(modelID, "o") || strings.HasPrefix(modelID, "gpt-5") || strings.HasPrefix(modelID, "gpt-5-chat")
+	return strings.HasPrefix(modelID, "o1") || strings.Contains(modelID, "-o1") ||
+		strings.HasPrefix(modelID, "o3") || strings.Contains(modelID, "-o3") ||
+		strings.HasPrefix(modelID, "o4") || strings.Contains(modelID, "-o4") ||
+		strings.HasPrefix(modelID, "oss") || strings.Contains(modelID, "-oss") ||
+		strings.Contains(modelID, "gpt-5") || strings.Contains(modelID, "gpt-5-chat")
 }
 
 func isSearchPreviewModel(modelID string) bool {
@@ -565,13 +569,14 @@ func isSearchPreviewModel(modelID string) bool {
 }
 
 func supportsFlexProcessing(modelID string) bool {
-	return strings.HasPrefix(modelID, "o3") || strings.HasPrefix(modelID, "o4-mini") || strings.HasPrefix(modelID, "gpt-5")
+	return strings.HasPrefix(modelID, "o3") || strings.Contains(modelID, "-o3") ||
+		strings.Contains(modelID, "o4-mini") || strings.Contains(modelID, "gpt-5")
 }
 
 func supportsPriorityProcessing(modelID string) bool {
-	return strings.HasPrefix(modelID, "gpt-4") || strings.HasPrefix(modelID, "gpt-5") ||
-		strings.HasPrefix(modelID, "gpt-5-mini") || strings.HasPrefix(modelID, "o3") ||
-		strings.HasPrefix(modelID, "o4-mini")
+	return strings.Contains(modelID, "gpt-4") || strings.Contains(modelID, "gpt-5") ||
+		strings.Contains(modelID, "gpt-5-mini") || strings.HasPrefix(modelID, "o3") ||
+		strings.Contains(modelID, "-o3") || strings.Contains(modelID, "o4-mini")
 }
 
 func toOpenAiTools(tools []fantasy.Tool, toolChoice *fantasy.ToolChoice) (openAiTools []openai.ChatCompletionToolUnionParam, openAiToolChoice *openai.ChatCompletionToolChoiceOptionUnionParam, warnings []fantasy.CallWarning) {

--- a/providers/openai/responses_language_model.go
+++ b/providers/openai/responses_language_model.go
@@ -56,16 +56,17 @@ type responsesModelConfig struct {
 
 func getResponsesModelConfig(modelID string) responsesModelConfig {
 	supportsFlexProcessing := strings.HasPrefix(modelID, "o3") ||
-		strings.HasPrefix(modelID, "o4-mini") ||
-		(strings.HasPrefix(modelID, "gpt-5") && !strings.HasPrefix(modelID, "gpt-5-chat"))
+		strings.Contains(modelID, "-o3") || strings.Contains(modelID, "o4-mini") ||
+		(strings.Contains(modelID, "gpt-5") && !strings.Contains(modelID, "gpt-5-chat"))
 
-	supportsPriorityProcessing := strings.HasPrefix(modelID, "gpt-4") ||
-		strings.HasPrefix(modelID, "gpt-5-mini") ||
-		(strings.HasPrefix(modelID, "gpt-5") &&
-			!strings.HasPrefix(modelID, "gpt-5-nano") &&
-			!strings.HasPrefix(modelID, "gpt-5-chat")) ||
+	supportsPriorityProcessing := strings.Contains(modelID, "gpt-4") ||
+		strings.Contains(modelID, "gpt-5-mini") ||
+		(strings.Contains(modelID, "gpt-5") &&
+			!strings.Contains(modelID, "gpt-5-nano") &&
+			!strings.Contains(modelID, "gpt-5-chat")) ||
 		strings.HasPrefix(modelID, "o3") ||
-		strings.HasPrefix(modelID, "o4-mini")
+		strings.Contains(modelID, "-o3") ||
+		strings.Contains(modelID, "o4-mini")
 
 	defaults := responsesModelConfig{
 		requiredAutoTruncation:     false,
@@ -74,7 +75,7 @@ func getResponsesModelConfig(modelID string) responsesModelConfig {
 		supportsPriorityProcessing: supportsPriorityProcessing,
 	}
 
-	if strings.HasPrefix(modelID, "gpt-5-chat") {
+	if strings.Contains(modelID, "gpt-5-chat") {
 		return responsesModelConfig{
 			isReasoningModel:           false,
 			systemMessageMode:          defaults.systemMessageMode,
@@ -84,11 +85,13 @@ func getResponsesModelConfig(modelID string) responsesModelConfig {
 		}
 	}
 
-	if strings.HasPrefix(modelID, "o") ||
-		strings.HasPrefix(modelID, "gpt-5") ||
-		strings.HasPrefix(modelID, "codex-") ||
-		strings.HasPrefix(modelID, "computer-use") {
-		if strings.HasPrefix(modelID, "o1-mini") || strings.HasPrefix(modelID, "o1-preview") {
+	if strings.HasPrefix(modelID, "o1") || strings.Contains(modelID, "-o1") ||
+		strings.HasPrefix(modelID, "o3") || strings.Contains(modelID, "-o3") ||
+		strings.HasPrefix(modelID, "o4") || strings.Contains(modelID, "-o4") ||
+		strings.HasPrefix(modelID, "oss") || strings.Contains(modelID, "-oss") ||
+		strings.Contains(modelID, "gpt-5") || strings.Contains(modelID, "codex-") ||
+		strings.Contains(modelID, "computer-use") {
+		if strings.Contains(modelID, "o1-mini") || strings.Contains(modelID, "o1-preview") {
 			return responsesModelConfig{
 				isReasoningModel:           true,
 				systemMessageMode:          "remove",


### PR DESCRIPTION
Some gpt model IDs provided using Azure have prefixes before the model type, like Org-Name-gpt-5. This changes model ID checks to look for the model type anywhere in the model ID, not just at the start. Closes #73.

This works with the current set of provider tests and should be fairly robust, but there could be issues with certain models that contain some of the checked-for strings.

I made some tests based on `providertests/azure_test.go` for my organization which are now passing but it isn't something I can add here. Is there some other way this could be tested?

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have created a discussion that was approved by a maintainer (for new features).
