### PR TITLE
fix(openrouter): add Gemini compatibility layer for tool message roles

### DIFF
--- a/providers/openrouter/gemini_compatibility.go
+++ b/providers/openrouter/gemini_compatibility.go
@@ -1,0 +1,93 @@
+package openrouter
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+)
+
+// GeminiCompatibilityTransport wraps an HTTP client to make requests compatible
+// with Google Gemini models accessed through OpenRouter.
+//
+// Google Gemini models use "user" role for tool/function call results, while
+// OpenRouter's API spec (following OpenAI's standard) uses "tool" role.
+// OpenRouter does not automatically transform this for Gemini models, so we
+// need to handle it client-side.
+//
+// References:
+// - OpenRouter API: https://openrouter.ai/docs/features/tool-calling (uses "tool" role)
+// - Gemini API: https://ai.google.dev/gemini-api/docs/function-calling (uses "user" role)
+type GeminiCompatibilityTransport struct {
+	Base *http.Client
+}
+
+// Do intercepts HTTP requests to OpenRouter and transforms message roles
+// for Gemini model compatibility.
+func (t *GeminiCompatibilityTransport) Do(req *http.Request) (*http.Response, error) {
+	// Only process POST requests with a body (chat completion requests)
+	if req.Method != "POST" || req.Body == nil {
+		return t.Base.Do(req)
+	}
+
+	// Read the request body
+	bodyBytes, err := io.ReadAll(req.Body)
+	req.Body.Close()
+	if err != nil {
+		return t.Base.Do(req)
+	}
+
+	// Parse as JSON
+	var requestData map[string]any
+	if err := json.Unmarshal(bodyBytes, &requestData); err != nil {
+		// Not JSON or malformed - pass through unchanged
+		req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+		return t.Base.Do(req)
+	}
+
+	// Check if this is a Gemini model
+	isGemini := false
+	if model, ok := requestData["model"].(string); ok {
+		modelLower := strings.ToLower(model)
+		isGemini = strings.Contains(modelLower, "gemini")
+	}
+
+	// Only apply transformation for Gemini models
+	if !isGemini {
+		req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+		return t.Base.Do(req)
+	}
+
+	// Convert role: "tool" to role: "user" for Gemini compatibility
+	if messages, ok := requestData["messages"].([]any); ok {
+		toolRoleConverted := 0
+		for _, msg := range messages {
+			if msgMap, ok := msg.(map[string]any); ok {
+				if role, ok := msgMap["role"].(string); ok && role == "tool" {
+					msgMap["role"] = "user"
+					toolRoleConverted++
+				}
+			}
+		}
+
+		if toolRoleConverted > 0 {
+			slog.Debug("Converted tool role to user for Gemini compatibility",
+				"count", toolRoleConverted,
+				"model", requestData["model"])
+
+			// Re-serialize with changes
+			modifiedBytes, err := json.Marshal(requestData)
+			if err == nil {
+				bodyBytes = modifiedBytes
+				req.ContentLength = int64(len(modifiedBytes))
+				req.Header.Set("Content-Length", string(rune(len(modifiedBytes))))
+			}
+		}
+	}
+
+	// Restore body with potentially modified content
+	req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+	return t.Base.Do(req)
+}

--- a/providers/openrouter/openrouter.go
+++ b/providers/openrouter/openrouter.go
@@ -3,6 +3,7 @@ package openrouter
 
 import (
 	"encoding/json"
+	"net/http"
 
 	"charm.land/fantasy"
 	"charm.land/fantasy/providers/openai"
@@ -53,8 +54,13 @@ func New(opts ...Option) (fantasy.Provider, error) {
 		objectMode = fantasy.ObjectModeTool
 	}
 
+	// Wrap HTTP client with Gemini compatibility layer
+	// This converts "tool" role to "user" role for Gemini models which don't support the "tool" role
 	providerOptions.openaiOptions = append(
 		providerOptions.openaiOptions,
+		openai.WithHTTPClient(&GeminiCompatibilityTransport{
+			Base: http.DefaultClient,
+		}),
 		openai.WithLanguageModelOptions(providerOptions.languageModelOptions...),
 		openai.WithObjectMode(objectMode),
 	)


### PR DESCRIPTION
# Fix: Add Gemini Compatibility Layer for Tool Message Roles

Fixes #80

## Summary

This PR adds support for Google Gemini models accessed through OpenRouter by implementing a compatibility layer that transforms tool call result message roles.

## Problem

Google Gemini models (including the newly released Gemini 3 Pro Preview) fail on multi-turn conversations when using tool calling via OpenRouter. The issue occurs because:

1. **OpenRouter's API** follows OpenAI's standard and uses `role: "tool"` for tool call results
2. **Gemini's native API** expects `role: "user"` for function call results
3. **OpenRouter does not automatically transform** message roles when routing to Gemini models

### Error Observed
```
Request contains an invalid argument
```

This error only occurs on continuation requests (second+ turn), not the initial request, because tool results only appear in conversation history after the first tool call.

## Solution

Added `GeminiCompatibilityTransport` that:

- Intercepts HTTP requests to OpenRouter
- Detects Gemini models by checking if `model` contains "gemini"
- Converts `role: "tool"` → `role: "user"` **only for Gemini models**
- Leaves all other models unchanged to maintain compatibility

### Files Changed

1. **`providers/openrouter/gemini_compatibility.go`** (new)
   - HTTP transport wrapper with detailed documentation
   - Model-specific transformation logic
   - Debug logging for transparency

2. **`providers/openrouter/openrouter.go`** (modified)
   - Added `net/http` import
   - Wrapped default HTTP client with `GeminiCompatibilityTransport`
   - Added inline comment explaining the purpose

## Testing

Tested with:
- Gemini 3 Pro Preview via OpenRouter
- Multi-turn conversations with tool calling
- Verified other OpenRouter models remain unaffected

### Test Configuration
```json
{
  "provider": "openrouter",
  "model": "google/gemini-3-pro-preview",
  "tools": ["read_file", "write_file", "bash"]
}
```