### PR TITLE
fix(openaicompat): handle cerebras/glm-4.6 thinking

### DIFF
--- a/providers/openaicompat/language_model_hooks.go
+++ b/providers/openaicompat/language_model_hooks.go
@@ -54,9 +54,9 @@ func ExtraContentFunc(choice openaisdk.ChatCompletionChoice) []fantasy.Content {
 	if err != nil {
 		return content
 	}
-	if reasoningData.ReasoningContent != "" {
+	if reasoning := reasoningData.GetReasoning(); reasoning != "" {
 		content = append(content, fantasy.ReasoningContent{
-			Text: reasoningData.ReasoningContent,
+			Text: reasoning,
 		})
 	}
 	return content
@@ -110,11 +110,11 @@ func StreamExtraFunc(chunk openaisdk.ChatCompletionChunk, yield func(fantasy.Str
 				Delta: reasoningContent,
 			})
 		}
-		if reasoningData.ReasoningContent != "" {
+		if reasoning := reasoningData.GetReasoning(); reasoning != "" {
 			if !reasoningStarted {
 				ctx[reasoningStartedCtx] = true
 			}
-			return ctx, emitEvent(reasoningData.ReasoningContent)
+			return ctx, emitEvent(reasoning)
 		}
 		if reasoningStarted && (choice.Delta.Content != "" || len(choice.Delta.ToolCalls) > 0) {
 			ctx[reasoningStartedCtx] = false

--- a/providers/openaicompat/provider_options.go
+++ b/providers/openaicompat/provider_options.go
@@ -31,8 +31,21 @@ type ProviderOptions struct {
 }
 
 // ReasoningData represents reasoning data for OpenAI-compatible provider.
+// Different providers may use different field names (reasoning_content vs reasoning).
 type ReasoningData struct {
+	// Most common
 	ReasoningContent string `json:"reasoning_content"`
+	// So far, only used by Cerebras specifically for GLM 4.6
+	Reasoning string `json:"reasoning"`
+}
+
+// GetReasoning returns the reasoning content whether it's in `reasoning` or
+// `reasoning_content` JSON fields.
+func (r *ReasoningData) GetReasoning() string {
+	if r.ReasoningContent != "" {
+		return r.ReasoningContent
+	}
+	return r.Reasoning
 }
 
 // Options implements the ProviderOptions interface.


### PR DESCRIPTION
Adds GetReasoning method to handle different providers using either `reasoning` or `reasoning_content` field names. So far, Cerebras is the only one I've noticed using this structure.

https://inference-docs.cerebras.ai/capabilities/reasoning

Assisted-by: GLM 4.6 via Crush

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
