### PR TITLE
fix(openai): gpt 5.1 codex max should use responses api

### DIFF
--- a/providers/openai/responses_options.go
+++ b/providers/openai/responses_options.go
@@ -155,6 +155,7 @@ var responsesReasoningModelIDs = []string{
 	"gpt-5-pro",
 	"gpt-5.1",
 	"gpt-5.1-codex",
+	"gpt-5.1-codex-max",
 	"gpt-5.1-codex-mini",
 	"gpt-5.1-chat",
 	"gpt-oss-120b",


### PR DESCRIPTION
* Catwalk PR: https://github.com/charmbracelet/catwalk/pull/124