### PR TITLE
fix(errors): enhance retry logic for ProviderError

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -3,6 +3,7 @@ package fantasy
 import (
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 
@@ -49,7 +50,14 @@ func (m *ProviderError) Error() string {
 
 // IsRetryable checks if the error is retryable based on the status code.
 func (m *ProviderError) IsRetryable() bool {
-	return m.StatusCode == http.StatusRequestTimeout || m.StatusCode == http.StatusConflict || m.StatusCode == http.StatusTooManyRequests
+	// According to OpenAI's Go SDK [1], we should retry on connection errors and server internal errors.
+	// [1] https://github.com/openai/openai-go/blob/719cc10a9a2f8b1ad5bc60f2aac279bf6646a842/internal/requestconfig/requestconfig.go#L250
+
+	if errors.Is(m.Cause, io.ErrUnexpectedEOF) {
+		return true
+	}
+
+	return m.StatusCode == http.StatusRequestTimeout || m.StatusCode == http.StatusConflict || m.StatusCode == http.StatusTooManyRequests || m.StatusCode >= http.StatusInternalServerError
 }
 
 // RetryError represents an error that occurred during retry operations.


### PR DESCRIPTION
Align part of the retry logic to the OpenAI offical SDK.

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have created a discussion that was approved by a maintainer (for new features).
