### PR TITLE
fix(openai,openaicompat): drop empty messages with warning

### DIFF
--- a/providers/openai/language_model_hooks.go
+++ b/providers/openai/language_model_hooks.go
@@ -437,6 +437,13 @@ func DefaultToPrompt(prompt fantasy.Prompt, _, _ string) ([]openai.ChatCompletio
 					}
 				}
 			}
+			if !hasVisibleUserContent(content) {
+				warnings = append(warnings, fantasy.CallWarning{
+					Type:    fantasy.CallWarningTypeOther,
+					Message: "dropping empty user message (contains neither user-facing content nor tool results)",
+				})
+				continue
+			}
 			messages = append(messages, openai.UserMessage(content))
 		case fantasy.MessageRoleAssistant:
 			// simple assistant message just text content
@@ -491,6 +498,13 @@ func DefaultToPrompt(prompt fantasy.Prompt, _, _ string) ([]openai.ChatCompletio
 						})
 				}
 			}
+			if !hasVisibleAssistantContent(&assistantMsg) {
+				warnings = append(warnings, fantasy.CallWarning{
+					Type:    fantasy.CallWarningTypeOther,
+					Message: "dropping empty assistant message (contains neither user-facing content nor tool calls)",
+				})
+				continue
+			}
 			messages = append(messages, openai.ChatCompletionMessageParamUnion{
 				OfAssistant: &assistantMsg,
 			})
@@ -540,4 +554,25 @@ func DefaultToPrompt(prompt fantasy.Prompt, _, _ string) ([]openai.ChatCompletio
 		}
 	}
 	return messages, warnings
+}
+
+func hasVisibleUserContent(content []openai.ChatCompletionContentPartUnionParam) bool {
+	for _, part := range content {
+		if part.OfText != nil || part.OfImageURL != nil || part.OfInputAudio != nil || part.OfFile != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func hasVisibleAssistantContent(msg *openai.ChatCompletionAssistantMessageParam) bool {
+	// Check if there's text content
+	if !param.IsOmitted(msg.Content.OfString) || len(msg.Content.OfArrayOfContentParts) > 0 {
+		return true
+	}
+	// Check if there are tool calls
+	if len(msg.ToolCalls) > 0 {
+		return true
+	}
+	return false
 }

--- a/providers/openai/responses_language_model.go
+++ b/providers/openai/responses_language_model.go
@@ -440,9 +440,18 @@ func toResponsesPrompt(prompt fantasy.Prompt, systemMessageMode string) (respons
 				}
 			}
 
+			if !hasVisibleResponsesUserContent(contentParts) {
+				warnings = append(warnings, fantasy.CallWarning{
+					Type:    fantasy.CallWarningTypeOther,
+					Message: "dropping empty user message (contains neither user-facing content nor tool results)",
+				})
+				continue
+			}
+
 			input = append(input, responses.ResponseInputItemParamOfMessage(contentParts, responses.EasyInputMessageRoleUser))
 
 		case fantasy.MessageRoleAssistant:
+			startIdx := len(input)
 			for _, c := range msg.Content {
 				switch c.GetType() {
 				case fantasy.ContentTypeText:
@@ -513,6 +522,16 @@ func toResponsesPrompt(prompt fantasy.Prompt, systemMessageMode string) (respons
 				}
 			}
 
+			if !hasVisibleResponsesAssistantContent(input, startIdx) {
+				warnings = append(warnings, fantasy.CallWarning{
+					Type:    fantasy.CallWarningTypeOther,
+					Message: "dropping empty assistant message (contains neither user-facing content nor tool calls)",
+				})
+				// Remove any items that were added during this iteration
+				input = input[:startIdx]
+				continue
+			}
+
 		case fantasy.MessageRoleTool:
 			for _, c := range msg.Content {
 				if c.GetType() != fantasy.ContentTypeToolResult {
@@ -562,6 +581,20 @@ func toResponsesPrompt(prompt fantasy.Prompt, systemMessageMode string) (respons
 	}
 
 	return input, warnings
+}
+
+func hasVisibleResponsesUserContent(content responses.ResponseInputMessageContentListParam) bool {
+	return len(content) > 0
+}
+
+func hasVisibleResponsesAssistantContent(items []responses.ResponseInputItemUnionParam, startIdx int) bool {
+	// Check if we added any assistant content parts from this message
+	for i := startIdx; i < len(items); i++ {
+		if items[i].OfMessage != nil || items[i].OfFunctionCall != nil {
+			return true
+		}
+	}
+	return false
 }
 
 func toResponsesTools(tools []fantasy.Tool, toolChoice *fantasy.ToolChoice, options *ResponsesProviderOptions) ([]responses.ToolUnionParam, responses.ResponseNewParamsToolChoiceUnion, []fantasy.CallWarning) {


### PR DESCRIPTION
* Assisted-by: Anthropic and Grok via Crush <crush@charm.land>
* Follow-up of https://github.com/charmbracelet/fantasy/pull/79

This issue happens when you interrupt Grok while it's thinking and then send another prompt.

I confirm I tested this change and it properly fixes the issue.

In theory this was only needed for OpenAI-compact. The problem wasn't happening for OpenAI models, but I decided to port the fix to both providers.