### PR TITLE
fix(aws-bedrock): address `panic` when it's not possible to load config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	cloud.google.com/go/auth v0.17.0
 	github.com/RealAlexandreAI/json-repair v0.0.14
 	github.com/aws/aws-sdk-go-v2 v1.41.0
+	github.com/aws/aws-sdk-go-v2/config v1.27.27
 	github.com/aws/smithy-go v1.24.0
 	github.com/charmbracelet/anthropic-sdk-go v0.0.0-20251024181547-21d6f3d9a904
 	github.com/charmbracelet/x/exp/slice v0.0.0-20250904123553-b4e2667e5ad5
@@ -28,7 +29,6 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.17.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.3 // indirect
-	github.com/aws/aws-sdk-go-v2/config v1.27.27 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.27 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.11 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.15 // indirect

--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -14,6 +14,7 @@ import (
 
 	"charm.land/fantasy"
 	"charm.land/fantasy/object"
+	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/charmbracelet/anthropic-sdk-go"
 	"github.com/charmbracelet/anthropic-sdk-go/bedrock"
 	"github.com/charmbracelet/anthropic-sdk-go/option"
@@ -182,10 +183,12 @@ func (a *provider) LanguageModel(ctx context.Context, modelID string) (fantasy.L
 				bedrock.WithConfig(bedrockBasicAuthConfig(a.options.apiKey)),
 			)
 		} else {
-			clientOptions = append(
-				clientOptions,
-				bedrock.WithLoadDefaultConfig(ctx),
-			)
+			if cfg, err := config.LoadDefaultConfig(ctx); err == nil {
+				clientOptions = append(
+					clientOptions,
+					bedrock.WithConfig(cfg),
+				)
+			}
 		}
 	}
 	return languageModel{


### PR DESCRIPTION
* Fixes https://github.com/charmbracelet/crush/issues/1674

This currently affects Crush on onboarding when the configured AWS config is not valid.