### PR TITLE
feat: detect context-too-large errors

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -38,6 +38,10 @@ type ProviderError struct {
 	RequestBody     []byte
 	ResponseHeaders map[string]string
 	ResponseBody    []byte
+
+	ContextUsedTokens  int
+	ContextMaxTokens   int
+	ContextTooLargeErr bool
 }
 
 func (m *ProviderError) Error() string {
@@ -50,6 +54,11 @@ func (m *ProviderError) Error() string {
 // IsRetryable checks if the error is retryable based on the status code.
 func (m *ProviderError) IsRetryable() bool {
 	return m.StatusCode == http.StatusRequestTimeout || m.StatusCode == http.StatusConflict || m.StatusCode == http.StatusTooManyRequests
+}
+
+// IsContextTooLarge checks if the error is due to the context exceeding the model's limit.
+func (m *ProviderError) IsContextTooLarge() bool {
+	return m.ContextTooLargeErr || m.ContextMaxTokens > 0 || m.ContextUsedTokens > 0
 }
 
 // RetryError represents an error that occurred during retry operations.

--- a/providers/anthropic/error.go
+++ b/providers/anthropic/error.go
@@ -4,16 +4,20 @@ import (
 	"cmp"
 	"errors"
 	"net/http"
+	"regexp"
+	"strconv"
 	"strings"
 
 	"charm.land/fantasy"
 	"github.com/charmbracelet/anthropic-sdk-go"
 )
 
+var anthropicContextPattern = regexp.MustCompile(`prompt is too long:\s*(\d+)\s*tokens?\s*>\s*(\d+)\s*maximum`)
+
 func toProviderErr(err error) error {
 	var apiErr *anthropic.Error
 	if errors.As(err, &apiErr) {
-		return &fantasy.ProviderError{
+		providerErr := &fantasy.ProviderError{
 			Title:           cmp.Or(fantasy.ErrorTitleForStatusCode(apiErr.StatusCode), "provider request failed"),
 			Message:         apiErr.Error(),
 			Cause:           apiErr,
@@ -23,8 +27,23 @@ func toProviderErr(err error) error {
 			ResponseHeaders: toHeaderMap(apiErr.Response.Header),
 			ResponseBody:    apiErr.DumpResponse(true),
 		}
+
+		parseContextTooLargeError(apiErr.Error(), providerErr)
+
+		return providerErr
 	}
 	return err
+}
+
+func parseContextTooLargeError(message string, providerErr *fantasy.ProviderError) {
+	matches := anthropicContextPattern.FindStringSubmatch(message)
+	if matches == nil {
+		return
+	}
+
+	providerErr.ContextTooLargeErr = true
+	providerErr.ContextUsedTokens, _ = strconv.Atoi(matches[1])
+	providerErr.ContextMaxTokens, _ = strconv.Atoi(matches[2])
 }
 
 func toHeaderMap(in http.Header) (out map[string]string) {

--- a/providers/google/error.go
+++ b/providers/google/error.go
@@ -3,21 +3,40 @@ package google
 import (
 	"cmp"
 	"errors"
+	"regexp"
+	"strconv"
 
 	"charm.land/fantasy"
 	"google.golang.org/genai"
 )
+
+var googleContextPattern = regexp.MustCompile(`input token count.*?(\d+).*?exceeds.*?maximum.*?(\d+)`)
 
 func toProviderErr(err error) error {
 	var apiErr genai.APIError
 	if !errors.As(err, &apiErr) {
 		return err
 	}
-	return &fantasy.ProviderError{
+
+	providerErr := &fantasy.ProviderError{
 		Message:      apiErr.Message,
 		Title:        cmp.Or(fantasy.ErrorTitleForStatusCode(apiErr.Code), "provider request failed"),
 		Cause:        err,
 		StatusCode:   apiErr.Code,
 		ResponseBody: []byte(apiErr.Message),
 	}
+
+	parseContextTooLargeError(apiErr.Message, providerErr)
+
+	return providerErr
+}
+
+func parseContextTooLargeError(message string, providerErr *fantasy.ProviderError) {
+	matches := googleContextPattern.FindStringSubmatch(message)
+	if matches == nil {
+		return
+	}
+	providerErr.ContextTooLargeErr = true
+	providerErr.ContextUsedTokens, _ = strconv.Atoi(matches[1])
+	providerErr.ContextMaxTokens, _ = strconv.Atoi(matches[2])
 }


### PR DESCRIPTION
- [X] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).

Add `IsContextTooLarge()` to `ProviderError` for detecting when prompts exceed model context limits.

Parses token counts from Anthropic, OpenAI (and compatible), and Google error messages. Tested manually against those provider APIs. 
 
Usage: 

 ```go
  var providerErr *fantasy.ProviderError
  if errors.As(err, &providerErr) && providerErr.IsContextTooLarge() {
      fmt.Printf("Context exceeded: %d/%d tokens\n",
          providerErr.ContextUsedTokens,
          providerErr.ContextMaxTokens)
  }
  ```
  
This will allow Crush to detect context overflow and prompt the user to summarize (or follow another recovery mechanism) rather than showing a generic error.

<img width="439" height="551" alt="Screenshot 2026-01-27 at 3 25 01 PM" src="https://github.com/user-attachments/assets/4d8ef25b-81b5-4002-808f-c59deae95582" />


