### PR TITLE
fix: normalize mcp  tool schemas for openai compatibility

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -9,6 +9,8 @@ import (
 	"maps"
 	"slices"
 	"sync"
+
+	"charm.land/fantasy/schema"
 )
 
 // StepResult represents the result of a single step in an agent execution.
@@ -912,14 +914,16 @@ func (a *agent) prepareTools(tools []AgentTool, activeTools []string, disableAll
 			continue
 		}
 		info := tool.Info()
+		inputSchema := map[string]any{
+			"type":       "object",
+			"properties": info.Parameters,
+			"required":   info.Required,
+		}
+		schema.Normalize(inputSchema)
 		preparedTools = append(preparedTools, FunctionTool{
-			Name:        info.Name,
-			Description: info.Description,
-			InputSchema: map[string]any{
-				"type":       "object",
-				"properties": info.Parameters,
-				"required":   info.Required,
-			},
+			Name:            info.Name,
+			Description:     info.Description,
+			InputSchema:     inputSchema,
 			ProviderOptions: tool.ProviderOptions(),
 		})
 	}


### PR DESCRIPTION
Convert JSON Schema type arrays to `anyOf` and ensure bare array types have items, preventing OpenAI "array schema missing items" errors.

Assisted-by: Claude Opus 4.6 via Crush <crush@charm.land>

---

* https://github.com/charmbracelet/crush/pull/2026

This is needed for Docker MCP on Crush. Without this fix, any prompt for OpenAI models fails like this:

<img width="1118" height="167" alt="Screenshot 2026-02-13 at 16 23 14" src="https://github.com/user-attachments/assets/d428491c-81f9-41e5-affc-b1445ca622ed" />
