### PR TITLE
Fix spelling error in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Yeah! Fantasy is designed to support a wide variety of providers and models unde
 
 ## Work in Progress
 
-We built Fantasy to power [Crush](https://github.com/charmbracelet/crush), a hot coding agent for glamourously invincible development. Given that, Fantasy does not yet support things like:
+We built Fantasy to power [Crush](https://github.com/charmbracelet/crush), a hot coding agent for glamorously invincible development. Given that, Fantasy does not yet support things like:
 
 - Image models
 - Audio models


### PR DESCRIPTION
Corrected spelling of 'glamourously' to 'glamorously' in README.

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
