### PR TITLE
feat(providers/anthropic): add EffortXHigh constant

### DIFF
--- a/providers/anthropic/provider_options.go
+++ b/providers/anthropic/provider_options.go
@@ -19,6 +19,8 @@ const (
 	EffortMedium Effort = "medium"
 	// EffortHigh represents high output effort.
 	EffortHigh Effort = "high"
+	// EffortXHigh represents extra-high output effort.
+	EffortXHigh Effort = "xhigh"
 	// EffortMax represents maximum output effort.
 	EffortMax Effort = "max"
 )


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).

Adds `EffortXHigh` to the Anthropic provider for the `xhigh` effort level
introduced with Claude Opus 4.7, which sits between `high` and `max`.

`Effort` and the SDK's `OutputConfigEffort` are both string aliases, so
the value passes through to the API unchanged — no switch or validation
updates are needed.

Refs: https://www.anthropic.com/news/claude-opus-4-7

> [!NOTE]
> PR was written with Coder Agents but has been reviewed by a human