### PR TITLE
feat(openai): add gpt-5.5 Responses API models

### DIFF
--- a/providers/openai/responses_options.go
+++ b/providers/openai/responses_options.go
@@ -219,6 +219,8 @@ var responsesReasoningModelIDs = []string{
 	"gpt-5.4-mini",
 	"gpt-5.4-nano",
 	"gpt-5.4-codex",
+	"gpt-5.5",
+	"gpt-5.5-pro",
 	"gpt-oss-120b",
 }
 


### PR DESCRIPTION
Adds `gpt-5.5` and `gpt-5.5-pro` to the OpenAI Responses API reasoning model list so `IsResponsesModel` and `IsResponsesReasoningModel` recognize them as Responses API models.

Upstreams coder/fantasy#29.

Validation:
- `go test ./providers/openai -count=1`
- `go test ./... -count=1 -timeout=30m`

> Mux created this PR on behalf of Mike.
