### PR TITLE
fix(openai,openaicompat): apply WithName to provider lookup and Name()

### DIFF
--- a/providers/openai/openai.go
+++ b/providers/openai/openai.go
@@ -200,5 +200,5 @@ func (o *provider) LanguageModel(_ context.Context, modelID string) (fantasy.Lan
 }
 
 func (o *provider) Name() string {
-	return Name
+	return o.options.name
 }

--- a/providers/openaicompat/language_model_hooks.go
+++ b/providers/openaicompat/language_model_hooks.go
@@ -16,9 +16,9 @@ import (
 const reasoningStartedCtx = "reasoning_started"
 
 // PrepareCallFunc prepares the call for the language model.
-func PrepareCallFunc(_ fantasy.LanguageModel, params *openaisdk.ChatCompletionNewParams, call fantasy.Call) ([]fantasy.CallWarning, error) {
+func PrepareCallFunc(model fantasy.LanguageModel, params *openaisdk.ChatCompletionNewParams, call fantasy.Call) ([]fantasy.CallWarning, error) {
 	providerOptions := &ProviderOptions{}
-	if v, ok := call.ProviderOptions[Name]; ok {
+	if v, ok := call.ProviderOptions[model.Provider()]; ok {
 		providerOptions, ok = v.(*ProviderOptions)
 		if !ok {
 			return nil, &fantasy.Error{Title: "invalid argument", Message: "openai-compat provider options should be *openaicompat.ProviderOptions"}


### PR DESCRIPTION
The openaicompat PrepareCallFunc looked up ProviderOptions using the hardcoded "openai-compat" key, so any name supplied via WithName was silently ignored — users could not key their per-call options under a custom provider name. Switch the lookup to model.Provider() so it matches whatever name was configured.

Similarly, the openai provider's Name() method always returned the hardcoded "openai" constant, discarding the value passed to WithName. Return o.options.name instead so the configured name is reported consistently.

Fixes: #210 

- [ ] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
