### PR TITLE
fix(anthropic): preserve tool_use when ToolCallPart.Input is empty or malformed

### DIFF
--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -999,10 +999,9 @@ func toPrompt(prompt fantasy.Prompt, sendReasoningData bool) ([]anthropic.TextBl
 						if toolCall.ProviderExecuted {
 							// Reconstruct server_tool_use block for
 							// multi-turn round-tripping.
-							var inputAny any
-							err := json.Unmarshal([]byte(toolCall.Input), &inputAny)
-							if err != nil {
-								continue
+							inputAny, warning := decodeToolCallInputAny(toolCall)
+							if warning != nil {
+								warnings = append(warnings, *warning)
 							}
 							anthropicContent = append(anthropicContent, anthropic.ContentBlockParamUnion{
 								OfServerToolUse: &anthropic.ServerToolUseBlockParam{
@@ -1013,10 +1012,9 @@ func toPrompt(prompt fantasy.Prompt, sendReasoningData bool) ([]anthropic.TextBl
 							})
 							continue
 						}
-						var inputMap map[string]any
-						err := json.Unmarshal([]byte(toolCall.Input), &inputMap)
-						if err != nil {
-							continue
+						inputMap, warning := decodeToolCallInputMap(toolCall)
+						if warning != nil {
+							warnings = append(warnings, *warning)
 						}
 						toolUseBlock := anthropic.NewToolUseBlock(toolCall.ToolCallID, inputMap, toolCall.ToolName)
 						if cacheControl != nil {
@@ -1075,6 +1073,52 @@ func hasVisibleAssistantContent(content []anthropic.ContentBlockParamUnion) bool
 		}
 	}
 	return false
+}
+
+// decodeToolCallInputMap unmarshals a ToolCallPart.Input into a map for
+// reconstructing an Anthropic tool_use block. The Anthropic API rejects any
+// request whose tool_result lacks a matching tool_use in the previous
+// message, so this helper never drops the block: empty input becomes {},
+// and malformed input falls back to {} with a CallWarning. The caller still
+// emits a tool_use block with the original ToolCallID, preserving the pair.
+func decodeToolCallInputMap(toolCall fantasy.ToolCallPart) (map[string]any, *fantasy.CallWarning) {
+	if strings.TrimSpace(toolCall.Input) == "" {
+		return map[string]any{}, nil
+	}
+	var inputMap map[string]any
+	if err := json.Unmarshal([]byte(toolCall.Input), &inputMap); err != nil {
+		return map[string]any{}, &fantasy.CallWarning{
+			Type: fantasy.CallWarningTypeOther,
+			Message: fmt.Sprintf(
+				"tool call %q has malformed input JSON; emitting empty arguments to preserve tool_use ↔ tool_result pairing: %s",
+				toolCall.ToolCallID, err,
+			),
+		}
+	}
+	if inputMap == nil {
+		return map[string]any{}, nil
+	}
+	return inputMap, nil
+}
+
+// decodeToolCallInputAny is the server_tool_use counterpart to
+// decodeToolCallInputMap. ServerToolUseBlockParam.Input has type `any` so
+// nil is acceptable for the empty case.
+func decodeToolCallInputAny(toolCall fantasy.ToolCallPart) (any, *fantasy.CallWarning) {
+	if strings.TrimSpace(toolCall.Input) == "" {
+		return nil, nil
+	}
+	var inputAny any
+	if err := json.Unmarshal([]byte(toolCall.Input), &inputAny); err != nil {
+		return nil, &fantasy.CallWarning{
+			Type: fantasy.CallWarningTypeOther,
+			Message: fmt.Sprintf(
+				"server tool call %q has malformed input JSON; emitting empty arguments to preserve tool_use ↔ tool_result pairing: %s",
+				toolCall.ToolCallID, err,
+			),
+		}
+	}
+	return inputAny, nil
 }
 
 // buildWebSearchToolResultBlock constructs an Anthropic

--- a/providers/anthropic/anthropic_test.go
+++ b/providers/anthropic/anthropic_test.go
@@ -176,9 +176,14 @@ func TestToPrompt_DropsEmptyMessages(t *testing.T) {
 		require.Empty(t, warnings)
 	})
 
-	t.Run("should drop assistant messages with invalid tool input", func(t *testing.T) {
+	t.Run("should preserve tool_use block when input JSON is malformed", func(t *testing.T) {
 		t.Parallel()
 
+		// Anthropic's API rejects any request whose tool_result lacks a
+		// matching tool_use in the previous message. Dropping the tool_use
+		// because its input failed to parse leaves the next turn's
+		// tool_result orphaned and produces a 400. Emit the block with
+		// empty arguments instead, and surface the parse error as a warning.
 		prompt := fantasy.Prompt{
 			{
 				Role: fantasy.MessageRoleUser,
@@ -201,10 +206,56 @@ func TestToPrompt_DropsEmptyMessages(t *testing.T) {
 		systemBlocks, messages, warnings := toPrompt(prompt, true)
 
 		require.Empty(t, systemBlocks)
-		require.Len(t, messages, 1, "should only have user message")
+		require.Len(t, messages, 2, "user + assistant — assistant must be preserved so tool_result can pair")
+		assistant := messages[1]
+		require.Equal(t, anthropic.MessageParamRoleAssistant, assistant.Role)
+		require.Len(t, assistant.Content, 1)
+		toolUse := assistant.Content[0].OfToolUse
+		require.NotNil(t, toolUse, "tool_use block should be emitted even when input is malformed")
+		require.Equal(t, "call_123", toolUse.ID)
+		require.Equal(t, "get_weather", toolUse.Name)
 		require.Len(t, warnings, 1)
 		require.Equal(t, fantasy.CallWarningTypeOther, warnings[0].Type)
-		require.Contains(t, warnings[0].Message, "dropping empty assistant message")
+		require.Contains(t, warnings[0].Message, "malformed input JSON")
+		require.Contains(t, warnings[0].Message, "call_123")
+	})
+
+	t.Run("should preserve tool_use block when input is empty", func(t *testing.T) {
+		t.Parallel()
+
+		// Some upstream providers (notably DeepSeek's anthropic-compat
+		// endpoint) emit tool_use blocks with empty input for parameterless
+		// tool calls. Treat empty input as {} rather than dropping the
+		// block, since the next turn's tool_result still needs its pair.
+		prompt := fantasy.Prompt{
+			{
+				Role: fantasy.MessageRoleUser,
+				Content: []fantasy.MessagePart{
+					fantasy.TextPart{Text: "Hi"},
+				},
+			},
+			{
+				Role: fantasy.MessageRoleAssistant,
+				Content: []fantasy.MessagePart{
+					fantasy.ToolCallPart{
+						ToolCallID: "call_empty",
+						ToolName:   "ping",
+						Input:      "",
+					},
+				},
+			},
+		}
+
+		systemBlocks, messages, warnings := toPrompt(prompt, true)
+
+		require.Empty(t, systemBlocks)
+		require.Empty(t, warnings, "empty input is a valid round-trip; no warning")
+		require.Len(t, messages, 2)
+		require.Equal(t, anthropic.MessageParamRoleAssistant, messages[1].Role)
+		toolUse := messages[1].Content[0].OfToolUse
+		require.NotNil(t, toolUse)
+		require.Equal(t, "call_empty", toolUse.ID)
+		require.Equal(t, "ping", toolUse.Name)
 	})
 
 	t.Run("should keep assistant messages with reasoning and text", func(t *testing.T) {


### PR DESCRIPTION
## Summary

When `ToolCallPart.Input` is empty (`""`), null, or otherwise malformed JSON, `toPrompt` previously dropped the corresponding `tool_use` block silently. The agent loop has already executed the tool by that point and queued a `ToolResultPart` for the next user message, so the result survives without its parent. Anthropic's API enforces that every `tool_result` block have a matching `tool_use` in the previous message and rejects the next request with HTTP 400:

```
unexpected `messages.N.content.0: tool_use_id` found in `tool_result` blocks: <id>.
Each `tool_result` block must have a corresponding `tool_use` block in the previous message.
```

Reproduced via DeepSeek's anthropic-compat endpoint (`https://api.deepseek.com/anthropic/v1/messages`), where the model emits parameterless `tool_use` blocks with empty `input`. The bug is provider-agnostic — any anthropic-compat endpoint that emits empty/malformed input triggers it.

## Fix

Two new helpers (`decodeToolCallInputMap`, `decodeToolCallInputAny`) handle the empty/malformed cases:

- Empty/whitespace input → empty map (or nil for `ServerToolUseBlockParam.Input any`). No warning — empty input is a valid round-trip.
- Non-empty but malformed input → empty map + a `CallWarning` naming the tool call ID and the parse error. The block is still emitted so `tool_use ↔ tool_result` pairing is preserved.

Even malformed input is better surfaced as `{}` plus a warning than as a silently dropped block, because a dropped block guarantees a 400 on the next round-trip.

## Tests

- The previous test `should drop assistant messages with invalid tool input` pinned the drop as intended. Renamed and rewritten as `should preserve tool_use block when input JSON is malformed`.
- New test `should preserve tool_use block when input is empty`.

## Test plan

- [x] `go test ./providers/anthropic/...` passes
- [x] `go vet ./providers/anthropic/...` passes
- [x] `gofumpt -l` clean on modified files
- [x] Manually verify against DeepSeek's anthropic-compat endpoint with a parameterless tool call