### PR TITLE
feat: add `ExtraBody` provider option to openai-compat

### DIFF
--- a/providers/openaicompat/language_model_hooks.go
+++ b/providers/openaicompat/language_model_hooks.go
@@ -47,6 +47,9 @@ func PrepareCallFunc(model fantasy.LanguageModel, params *openaisdk.ChatCompleti
 	if providerOptions.User != nil {
 		params.User = param.NewOpt(*providerOptions.User)
 	}
+	if len(providerOptions.ExtraBody) > 0 {
+		params.SetExtraFields(providerOptions.ExtraBody)
+	}
 	return nil, nil
 }
 

--- a/providers/openaicompat/provider_options.go
+++ b/providers/openaicompat/provider_options.go
@@ -28,6 +28,7 @@ func init() {
 type ProviderOptions struct {
 	User            *string                 `json:"user"`
 	ReasoningEffort *openai.ReasoningEffort `json:"reasoning_effort"`
+	ExtraBody       map[string]any          `json:"extra_body,omitempty"`
 }
 
 // ReasoningData represents reasoning data for OpenAI-compatible provider.


### PR DESCRIPTION
* Crush PR: https://github.com/charmbracelet/crush/pull/2755

This was already present to some other providers, like Vercel and OpenRouter.