### PR TITLE
providers: add opt-out build tags to reduce binary size

### DIFF
--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -16,13 +16,9 @@ import (
 	"charm.land/fantasy"
 	"charm.land/fantasy/object"
 	"charm.land/fantasy/providers/internal/httpheaders"
-	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/charmbracelet/anthropic-sdk-go"
-	"github.com/charmbracelet/anthropic-sdk-go/bedrock"
 	"github.com/charmbracelet/anthropic-sdk-go/option"
 	"github.com/charmbracelet/anthropic-sdk-go/packages/param"
-	"github.com/charmbracelet/anthropic-sdk-go/vertex"
-	"golang.org/x/oauth2/google"
 )
 
 // betaRequestOptions converts beta flag strings into request
@@ -201,42 +197,17 @@ func (a *provider) LanguageModel(ctx context.Context, modelID string) (fantasy.L
 		clientOptions = append(clientOptions, option.WithHTTPClient(a.options.client))
 	}
 	if a.options.vertexProject != "" && a.options.vertexLocation != "" {
-		var credentials *google.Credentials
-		if a.options.skipAuth {
-			credentials = &google.Credentials{TokenSource: &googleDummyTokenSource{}}
-		} else {
-			var err error
-			credentials, err = google.FindDefaultCredentials(ctx, VertexAuthScope)
-			if err != nil {
-				return nil, err
-			}
+		var err error
+		clientOptions, err = a.configureVertexOptions(ctx, clientOptions)
+		if err != nil {
+			return nil, err
 		}
-
-		clientOptions = append(
-			clientOptions,
-			vertex.WithCredentials(
-				ctx,
-				a.options.vertexLocation,
-				a.options.vertexProject,
-				credentials,
-			),
-		)
 	}
 	if a.options.useBedrock {
-		modelID = bedrockPrefixModelWithRegion(modelID)
-
-		if a.options.skipAuth || a.options.apiKey != "" {
-			clientOptions = append(
-				clientOptions,
-				bedrock.WithConfig(bedrockBasicAuthConfig(a.options.apiKey)),
-			)
-		} else {
-			if cfg, err := config.LoadDefaultConfig(ctx); err == nil {
-				clientOptions = append(
-					clientOptions,
-					bedrock.WithConfig(cfg),
-				)
-			}
+		var err error
+		modelID, clientOptions, err = a.configureBedrockOptions(ctx, modelID, clientOptions)
+		if err != nil {
+			return nil, err
 		}
 		if a.options.baseURL != "" {
 			clientOptions = append(clientOptions, option.WithBaseURL(a.options.baseURL))

--- a/providers/anthropic/bedrock.go
+++ b/providers/anthropic/bedrock.go
@@ -1,3 +1,5 @@
+//go:build !noaws
+
 package anthropic
 
 import (

--- a/providers/anthropic/bedrock_lm.go
+++ b/providers/anthropic/bedrock_lm.go
@@ -1,0 +1,29 @@
+//go:build !noaws
+
+package anthropic
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/charmbracelet/anthropic-sdk-go/bedrock"
+	"github.com/charmbracelet/anthropic-sdk-go/option"
+)
+
+// configureBedrockOptions applies AWS Bedrock-specific options when useBedrock is set.
+// Returns the potentially modified modelID (with region prefix) and updated client options.
+func (a *provider) configureBedrockOptions(ctx context.Context, modelID string, clientOptions []option.RequestOption) (string, []option.RequestOption, error) {
+	modelID = bedrockPrefixModelWithRegion(modelID)
+
+	if a.options.skipAuth || a.options.apiKey != "" {
+		clientOptions = append(clientOptions, bedrock.WithConfig(bedrockBasicAuthConfig(a.options.apiKey)))
+	} else {
+		cfg, err := config.LoadDefaultConfig(ctx)
+		if err != nil {
+			return "", nil, err
+		}
+		clientOptions = append(clientOptions, bedrock.WithConfig(cfg))
+	}
+
+	return modelID, clientOptions, nil
+}

--- a/providers/anthropic/bedrock_lm_stub.go
+++ b/providers/anthropic/bedrock_lm_stub.go
@@ -1,0 +1,14 @@
+//go:build noaws
+
+package anthropic
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/charmbracelet/anthropic-sdk-go/option"
+)
+
+func (a *provider) configureBedrockOptions(ctx context.Context, modelID string, clientOptions []option.RequestOption) (string, []option.RequestOption, error) {
+	return "", nil, fmt.Errorf("AWS Bedrock support not compiled in; remove -tags noaws")
+}

--- a/providers/anthropic/google.go
+++ b/providers/anthropic/google.go
@@ -1,3 +1,5 @@
+//go:build !nogoogle
+
 package anthropic
 
 import (

--- a/providers/anthropic/vertex_lm.go
+++ b/providers/anthropic/vertex_lm.go
@@ -1,0 +1,35 @@
+//go:build !nogoogle
+
+package anthropic
+
+import (
+	"context"
+
+	"github.com/charmbracelet/anthropic-sdk-go/option"
+	"github.com/charmbracelet/anthropic-sdk-go/vertex"
+	"golang.org/x/oauth2/google"
+)
+
+// configureVertexOptions applies Google Vertex AI-specific options when both
+// vertexProject and vertexLocation are set.
+func (a *provider) configureVertexOptions(ctx context.Context, clientOptions []option.RequestOption) ([]option.RequestOption, error) {
+	var credentials *google.Credentials
+	if a.options.skipAuth {
+		credentials = &google.Credentials{TokenSource: &googleDummyTokenSource{}}
+	} else {
+		var err error
+		credentials, err = google.FindDefaultCredentials(ctx, VertexAuthScope)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	clientOptions = append(clientOptions, vertex.WithCredentials(
+		ctx,
+		a.options.vertexLocation,
+		a.options.vertexProject,
+		credentials,
+	))
+
+	return clientOptions, nil
+}

--- a/providers/anthropic/vertex_lm_stub.go
+++ b/providers/anthropic/vertex_lm_stub.go
@@ -1,0 +1,14 @@
+//go:build nogoogle
+
+package anthropic
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/charmbracelet/anthropic-sdk-go/option"
+)
+
+func (a *provider) configureVertexOptions(ctx context.Context, clientOptions []option.RequestOption) ([]option.RequestOption, error) {
+	return nil, fmt.Errorf("Google Vertex AI support not compiled in; remove -tags nogoogle")
+}

--- a/providers/azure/azure.go
+++ b/providers/azure/azure.go
@@ -1,3 +1,5 @@
+//go:build !noazure
+
 // Package azure provides an implementation of the fantasy AI SDK for Azure's language models.
 package azure
 

--- a/providers/azure/azure_test.go
+++ b/providers/azure/azure_test.go
@@ -1,3 +1,5 @@
+//go:build !noazure
+
 package azure
 
 import (

--- a/providers/azure/useragent_test.go
+++ b/providers/azure/useragent_test.go
@@ -1,3 +1,5 @@
+//go:build !noazure
+
 package azure
 
 import (

--- a/providers/bedrock/bedrock.go
+++ b/providers/bedrock/bedrock.go
@@ -1,3 +1,5 @@
+//go:build !noaws
+
 // Package bedrock provides an implementation of the fantasy AI SDK for AWS Bedrock's language models.
 package bedrock
 

--- a/providers/bedrock/useragent_test.go
+++ b/providers/bedrock/useragent_test.go
@@ -1,3 +1,5 @@
+//go:build !noaws
+
 package bedrock
 
 import (

--- a/providers/google/auth.go
+++ b/providers/google/auth.go
@@ -1,3 +1,5 @@
+//go:build !nogoogle
+
 // Package google provides an implementation of the fantasy AI SDK for Google's language models.
 package google
 

--- a/providers/google/call_useragent.go
+++ b/providers/google/call_useragent.go
@@ -1,3 +1,5 @@
+//go:build !nogoogle
+
 package google
 
 import (

--- a/providers/google/error.go
+++ b/providers/google/error.go
@@ -1,3 +1,5 @@
+//go:build !nogoogle
+
 package google
 
 import (

--- a/providers/google/error_test.go
+++ b/providers/google/error_test.go
@@ -1,3 +1,5 @@
+//go:build !nogoogle
+
 package google
 
 import (

--- a/providers/google/google.go
+++ b/providers/google/google.go
@@ -1,3 +1,5 @@
+//go:build !nogoogle
+
 package google
 
 import (

--- a/providers/google/provider_options.go
+++ b/providers/google/provider_options.go
@@ -1,3 +1,5 @@
+//go:build !nogoogle
+
 // Package google provides an implementation of the fantasy AI SDK for Google's language models.
 package google
 

--- a/providers/google/slice.go
+++ b/providers/google/slice.go
@@ -1,3 +1,5 @@
+//go:build !nogoogle
+
 package google
 
 func depointerSlice[T any](s []*T) []T {

--- a/providers/google/useragent_test.go
+++ b/providers/google/useragent_test.go
@@ -1,3 +1,5 @@
+//go:build !nogoogle
+
 package google
 
 import (

--- a/providers/kronk/kronk.go
+++ b/providers/kronk/kronk.go
@@ -1,3 +1,5 @@
+//go:build !nokronk
+
 // Package kronk provides an implementation of the fantasy AI SDK for local
 // models using the Kronk SDK.
 package kronk

--- a/providers/kronk/language_model.go
+++ b/providers/kronk/language_model.go
@@ -1,3 +1,5 @@
+//go:build !nokronk
+
 package kronk
 
 import (

--- a/providers/kronk/language_model_hooks.go
+++ b/providers/kronk/language_model_hooks.go
@@ -1,3 +1,5 @@
+//go:build !nokronk
+
 package kronk
 
 import (

--- a/providers/kronk/options.go
+++ b/providers/kronk/options.go
@@ -1,3 +1,5 @@
+//go:build !nokronk
+
 package kronk
 
 import (

--- a/providers/kronk/provider_options.go
+++ b/providers/kronk/provider_options.go
@@ -1,3 +1,5 @@
+//go:build !nokronk
+
 package kronk
 
 import (

--- a/providers/openrouter/language_model_hooks.go
+++ b/providers/openrouter/language_model_hooks.go
@@ -1,3 +1,5 @@
+//go:build !noopenrouter
+
 package openrouter
 
 import (

--- a/providers/openrouter/openrouter.go
+++ b/providers/openrouter/openrouter.go
@@ -1,3 +1,5 @@
+//go:build !noopenrouter
+
 // Package openrouter provides an implementation of the fantasy AI SDK for OpenRouter's language models.
 package openrouter
 

--- a/providers/openrouter/provider_options.go
+++ b/providers/openrouter/provider_options.go
@@ -1,3 +1,5 @@
+//go:build !noopenrouter
+
 // Package openrouter provides an implementation of the fantasy AI SDK for OpenRouter's language models.
 package openrouter
 

--- a/providers/openrouter/useragent_test.go
+++ b/providers/openrouter/useragent_test.go
@@ -1,3 +1,5 @@
+//go:build !noopenrouter
+
 package openrouter
 
 import (

--- a/providers/vercel/language_model_hooks.go
+++ b/providers/vercel/language_model_hooks.go
@@ -1,3 +1,5 @@
+//go:build !novercel
+
 package vercel
 
 import (

--- a/providers/vercel/provider_options.go
+++ b/providers/vercel/provider_options.go
@@ -1,3 +1,5 @@
+//go:build !novercel
+
 // Package vercel provides an implementation of the fantasy AI SDK for Vercel AI Gateway.
 package vercel
 

--- a/providers/vercel/vercel.go
+++ b/providers/vercel/vercel.go
@@ -1,3 +1,5 @@
+//go:build !novercel
+
 // Package vercel provides an implementation of the fantasy AI SDK for Vercel AI Gateway.
 package vercel
 

--- a/providertests/azure_responses_test.go
+++ b/providertests/azure_responses_test.go
@@ -1,3 +1,5 @@
+//go:build !noazure
+
 package providertests
 
 import (

--- a/providertests/azure_test.go
+++ b/providertests/azure_test.go
@@ -1,3 +1,5 @@
+//go:build !noazure
+
 package providertests
 
 import (

--- a/providertests/bedrock_test.go
+++ b/providertests/bedrock_test.go
@@ -1,3 +1,5 @@
+//go:build !noaws
+
 package providertests
 
 import (

--- a/providertests/google_test.go
+++ b/providertests/google_test.go
@@ -1,3 +1,5 @@
+//go:build !nogoogle
+
 package providertests
 
 import (

--- a/providertests/image_upload_test.go
+++ b/providertests/image_upload_test.go
@@ -1,3 +1,5 @@
+//go:build !nogoogle
+
 package providertests
 
 import (

--- a/providertests/openrouter_test.go
+++ b/providertests/openrouter_test.go
@@ -1,3 +1,5 @@
+//go:build !noopenrouter
+
 package providertests
 
 import (

--- a/providertests/provider_registry_test.go
+++ b/providertests/provider_registry_test.go
@@ -1,3 +1,5 @@
+//go:build !nogoogle && !noopenrouter
+
 package providertests
 
 import (

--- a/providertests/vercel_test.go
+++ b/providertests/vercel_test.go
@@ -1,3 +1,5 @@
+//go:build !novercel
+
 package providertests
 
 import (


### PR DESCRIPTION
Add opt-out build tags so users can exclude providers they don't use, reducing binary size significantly.

All providers compile by default — **no breaking change**. Pass `-tags` to exclude heavy dependency trees:

```bash
go build -tags "nogoogle,noaws,noazure,novercel,noopenrouter,nokronk" ./...
```

## Tags

| Tag           | Excludes                                         |
|---------------|--------------------------------------------------|
| `nogoogle`    | `providers/google` + anthropic vertex support    |
| `noaws`       | `providers/bedrock` + anthropic bedrock support  |
| `noazure`     | `providers/azure`                                |
| `novercel`    | `providers/vercel`                               |
| `noopenrouter`| `providers/openrouter`                           |
| `nokronk`     | `providers/kronk`                                |

## Implementation

- Every `.go` file in each optional provider package gets `//go:build !no<name>`
- `providertests/` files that import optional providers get matching tags
- Anthropic's `bedrock.go` / `google.go` gated behind `!noaws` / `!nogoogle`
- Bedrock/Vertex `LanguageModel` configuration extracted into build-tagged files (`bedrock_lm.go`, `vertex_lm.go`) with error-returning stubs for when excluded
- `anthropic.go` heavy imports (AWS SDK, Google OAuth) removed from main file

## Binary size impact

Stripped `-ldflags="-s -w"` binary with anthropic + openai + openaicompat:

| | Size |
|---|---|
| All providers compiled | 32 MB |
| Core only (all tags set) | 12 MB |
| **Savings** | **20 MB (63%)** |