### PR TITLE
fix: guard against nil response in Generate to prevent panic

### DIFF
--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -1171,6 +1171,9 @@ func (a languageModel) Generate(ctx context.Context, call fantasy.Call) (*fantas
 	if err != nil {
 		return nil, toProviderErr(err)
 	}
+	if response == nil {
+		return nil, &fantasy.Error{Title: "no response", Message: "provider returned nil response"}
+	}
 
 	var content []fantasy.Content
 	for _, block := range response.Content {

--- a/providers/openai/language_model.go
+++ b/providers/openai/language_model.go
@@ -251,6 +251,9 @@ func (o languageModel) Generate(ctx context.Context, call fantasy.Call) (*fantas
 	if err != nil {
 		return nil, toProviderErr(err)
 	}
+	if response == nil {
+		return nil, &fantasy.Error{Title: "no response", Message: "provider returned nil response"}
+	}
 
 	if len(response.Choices) == 0 {
 		return nil, &fantasy.Error{Title: "no response", Message: "no response generated"}

--- a/providers/openai/openai_test.go
+++ b/providers/openai/openai_test.go
@@ -2010,6 +2010,31 @@ func TestDoGenerate(t *testing.T) {
 		require.Equal(t, "ServiceTier", result.Warnings[0].Setting)
 		require.Contains(t, result.Warnings[0].Details, "priority processing is only available")
 	})
+
+	t.Run("should return error instead of panic on empty response body", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			// Write empty body — some OpenAI-compatible endpoints may do this
+			// under edge conditions, causing the SDK to return (nil, nil).
+		}))
+		defer server.Close()
+
+		provider, err := New(
+			WithAPIKey("test-api-key"),
+			WithBaseURL(server.URL),
+		)
+		require.NoError(t, err)
+		model, _ := provider.LanguageModel(t.Context(), "gpt-3.5-turbo")
+
+		require.NotPanics(t, func() {
+			_, _ = model.Generate(context.Background(), fantasy.Call{
+				Prompt: testPrompt,
+			})
+		})
+	})
 }
 
 type streamingMockServer struct {

--- a/providers/openai/responses_language_model.go
+++ b/providers/openai/responses_language_model.go
@@ -789,6 +789,9 @@ func (o responsesLanguageModel) Generate(ctx context.Context, call fantasy.Call)
 	if err != nil {
 		return nil, toProviderErr(err)
 	}
+	if response == nil {
+		return nil, &fantasy.Error{Title: "no response", Message: "provider returned nil response"}
+	}
 
 	if response.Error.Message != "" {
 		return nil, &fantasy.Error{


### PR DESCRIPTION
## Summary

Some OpenAI-compatible API endpoints may return a nil response with no error from the underlying SDK under certain edge conditions (empty response body, connection issues during response parsing, etc.).

When this happens, the `Generate` methods panic with a nil pointer dereference:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x10]

goroutine N [running]:
charm.land/fantasy/providers/openai.languageModel.Generate(...)
    providers/openai/language_model.go:255
```

Line 255 is `if len(response.Choices) == 0 {` — the response pointer itself is nil.

### Changes

Add a nil response check before accessing response fields in:

- **`providers/openai`**: `languageModel.Generate` (Chat Completions API) — guards `response.Choices`
- **`providers/openai`**: `responsesLanguageModel.Generate` (Responses API) — guards `response.Error`
- **`providers/anthropic`**: `languageModel.Generate` — guards `response.Content`

Each returns a descriptive `fantasy.Error` instead of panicking.

### Reproduction

Observed with an OpenAI-compatible endpoint (DeepSeek) returning an edge-case response that caused the SDK's `Chat.Completions.New` to return `(nil, nil)`. The calling application was using `openaicompat.New` with custom `base_url` and `headers`.

### Test Plan

- Added `TestDoGenerate/should_return_error_instead_of_panic_on_empty_response_body` — uses an HTTP test server returning an empty 200 body and verifies `Generate` does not panic.