### PR TITLE
chore: handle partial stream endings to prevent silent truncation

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -90,6 +90,19 @@ func (m *ProviderError) IsContextTooLarge() bool {
 	return m.ContextTooLargeErr || m.ContextMaxTokens > 0 || m.ContextUsedTokens > 0
 }
 
+// NewIncompleteStreamError returns a retryable ProviderError indicating that
+// an upstream stream closed cleanly without delivering its terminal signal
+// (finish_reason, stop_reason, response.completed, candidate.finishReason,
+// etc.). The cause is io.ErrUnexpectedEOF so ProviderError.IsRetryable()
+// engages and the retry middleware re-runs the step.
+func NewIncompleteStreamError() *ProviderError {
+	return &ProviderError{
+		Title:   "stream transport error",
+		Message: io.ErrUnexpectedEOF.Error(),
+		Cause:   io.ErrUnexpectedEOF,
+	}
+}
+
 // RetryError represents an error that occurred during retry operations.
 type RetryError struct {
 	Errors []error

--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -1511,6 +1511,15 @@ func (a languageModel) Stream(ctx context.Context, call fantasy.Call) (fantasy.S
 
 		err := stream.Err()
 		if err == nil || errors.Is(err, io.EOF) {
+			// Truncated stream: no terminal message_delta with stop_reason.
+			// Surface as a retryable error.
+			if acc.StopReason == "" {
+				yield(fantasy.StreamPart{
+					Type:  fantasy.StreamPartTypeError,
+					Error: fantasy.NewIncompleteStreamError(),
+				})
+				return
+			}
 			yield(fantasy.StreamPart{
 				Type:         fantasy.StreamPartTypeFinish,
 				ID:           acc.ID,

--- a/providers/anthropic/anthropic_test.go
+++ b/providers/anthropic/anthropic_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"math"
 	"net/http"
 	"net/http/httptest"
@@ -2383,4 +2384,49 @@ func TestStream_ComputerUseTool(t *testing.T) {
 	for i, h := range betaHeaders {
 		require.Contains(t, h, "computer-use-2025-01-24", "request %d", i)
 	}
+}
+
+func TestStream_TruncatedWithoutStopReason(t *testing.T) {
+	t.Parallel()
+
+	// Truncated stream: no terminal message_delta with stop_reason.
+	server, _ := newAnthropicStreamingServer([]string{
+		"event: message_start\n",
+		`data: {"type":"message_start","message":{"id":"msg_01","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"usage":{"input_tokens":10,"output_tokens":0}}}` + "\n\n",
+		"event: content_block_start\n",
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}` + "\n\n",
+		"event: content_block_delta\n",
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}` + "\n\n",
+		"event: content_block_stop\n",
+		`data: {"type":"content_block_stop","index":0}` + "\n\n",
+	})
+	defer server.Close()
+
+	provider, err := New(WithAPIKey("test-api-key"), WithBaseURL(server.URL))
+	require.NoError(t, err)
+	model, err := provider.LanguageModel(context.Background(), "claude-sonnet-4-20250514")
+	require.NoError(t, err)
+
+	stream, err := model.Stream(context.Background(), fantasy.Call{Prompt: testPrompt()})
+	require.NoError(t, err)
+
+	var parts []fantasy.StreamPart
+	stream(func(part fantasy.StreamPart) bool {
+		parts = append(parts, part)
+		return true
+	})
+
+	var errPart *fantasy.StreamPart
+	for i, part := range parts {
+		if part.Type == fantasy.StreamPartTypeError {
+			errPart = &parts[i]
+		}
+		require.NotEqual(t, fantasy.StreamPartTypeFinish, part.Type)
+	}
+	require.NotNil(t, errPart)
+
+	var providerErr *fantasy.ProviderError
+	require.ErrorAs(t, errPart.Error, &providerErr)
+	require.True(t, providerErr.IsRetryable())
+	require.ErrorIs(t, providerErr.Cause, io.ErrUnexpectedEOF)
 }

--- a/providers/google/google.go
+++ b/providers/google/google.go
@@ -867,7 +867,13 @@ func (g *languageModel) Stream(ctx context.Context, call fantasy.Call) (fantasy.
 		if len(toolCalls) > 0 {
 			finishReason = fantasy.FinishReasonToolCalls
 		} else if finishReason == "" {
-			finishReason = fantasy.FinishReasonStop
+			// Truncated stream: no candidate emitted a finishReason before
+			// close. Surface as a retryable error.
+			yield(fantasy.StreamPart{
+				Type:  fantasy.StreamPartTypeError,
+				Error: fantasy.NewIncompleteStreamError(),
+			})
+			return
 		}
 
 		var finalUsage fantasy.Usage

--- a/providers/openai/language_model.go
+++ b/providers/openai/language_model.go
@@ -564,6 +564,16 @@ func (o languageModel) Stream(ctx context.Context, call fantasy.Call) (fantasy.S
 					mappedFinishReason = fantasy.FinishReasonToolCalls
 				}
 			}
+			// Truncated stream: upstream closed without finish_reason and we
+			// can't infer a tool-call turn. Surface as a retryable error so
+			// the retry middleware re-runs the step.
+			if finishReason == "" && mappedFinishReason != fantasy.FinishReasonToolCalls {
+				yield(fantasy.StreamPart{
+					Type:  fantasy.StreamPartTypeError,
+					Error: fantasy.NewIncompleteStreamError(),
+				})
+				return
+			}
 			yield(fantasy.StreamPart{
 				Type:             fantasy.StreamPartTypeFinish,
 				Usage:            usage,

--- a/providers/openai/openai_test.go
+++ b/providers/openai/openai_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -3123,6 +3124,95 @@ func TestDoStream(t *testing.T) {
 		require.NotNil(t, finishPart)
 		require.Equal(t, fantasy.FinishReasonToolCalls, finishPart.FinishReason)
 	})
+
+	t.Run("should error when stream closes without finish_reason", func(t *testing.T) {
+		t.Parallel()
+
+		// Truncated SSE: deltas + [DONE] without any finish_reason chunk.
+		server := newStreamingMockServer()
+		defer server.close()
+
+		server.chunks = []string{
+			`data: {"id":"chatcmpl-trunc","object":"chat.completion.chunk","created":1,"model":"gpt-3.5-turbo","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}]}` + "\n\n",
+			`data: {"id":"chatcmpl-trunc","object":"chat.completion.chunk","created":1,"model":"gpt-3.5-turbo","choices":[{"index":0,"delta":{"content":"Hello"},"finish_reason":null}]}` + "\n\n",
+			"data: [DONE]\n\n",
+		}
+
+		provider, err := New(
+			WithAPIKey("test-api-key"),
+			WithBaseURL(server.server.URL),
+		)
+		require.NoError(t, err)
+		model, _ := provider.LanguageModel(t.Context(), "gpt-3.5-turbo")
+
+		stream, err := model.Stream(context.Background(), fantasy.Call{
+			Prompt: testPrompt,
+		})
+		require.NoError(t, err)
+
+		parts, err := collectStreamParts(stream)
+		require.NoError(t, err)
+
+		var errPart *fantasy.StreamPart
+		for i, part := range parts {
+			if part.Type == fantasy.StreamPartTypeError {
+				errPart = &parts[i]
+			}
+			require.NotEqual(t, fantasy.StreamPartTypeFinish, part.Type)
+		}
+		require.NotNil(t, errPart)
+
+		var providerErr *fantasy.ProviderError
+		require.ErrorAs(t, errPart.Error, &providerErr)
+		require.True(t, providerErr.IsRetryable())
+		require.ErrorIs(t, providerErr.Cause, io.ErrUnexpectedEOF)
+	})
+
+	t.Run("should still finish cleanly when tool_calls arrive without finish_reason", func(t *testing.T) {
+		t.Parallel()
+
+		// Tool-call-only turn without finish_reason: accumulator infers
+		// FinishReasonToolCalls; truncation guard must not fire.
+		server := newStreamingMockServer()
+		defer server.close()
+
+		server.chunks = []string{
+			`data: {"id":"chatcmpl-tc","object":"chat.completion.chunk","created":1,"model":"gpt-3.5-turbo","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"call_x","type":"function","function":{"name":"test-tool","arguments":"{\"a\":1}"}}]},"finish_reason":null}]}` + "\n\n",
+			"data: [DONE]\n\n",
+		}
+
+		provider, err := New(
+			WithAPIKey("test-api-key"),
+			WithBaseURL(server.server.URL),
+		)
+		require.NoError(t, err)
+		model, _ := provider.LanguageModel(t.Context(), "gpt-3.5-turbo")
+
+		stream, err := model.Stream(context.Background(), fantasy.Call{
+			Prompt: testPrompt,
+			Tools: []fantasy.Tool{fantasy.FunctionTool{
+				Name: "test-tool",
+				InputSchema: map[string]any{
+					"type":       "object",
+					"properties": map[string]any{"a": map[string]any{"type": "number"}},
+				},
+			}},
+		})
+		require.NoError(t, err)
+
+		parts, err := collectStreamParts(stream)
+		require.NoError(t, err)
+
+		var finish *fantasy.StreamPart
+		for i, part := range parts {
+			require.NotEqual(t, fantasy.StreamPartTypeError, part.Type)
+			if part.Type == fantasy.StreamPartTypeFinish {
+				finish = &parts[i]
+			}
+		}
+		require.NotNil(t, finish)
+		require.Equal(t, fantasy.FinishReasonToolCalls, finish.FinishReason)
+	})
 }
 
 func TestDefaultToPrompt_DropsEmptyMessages(t *testing.T) {
@@ -4337,4 +4427,49 @@ func TestResponsesStream_PreviousResponseIDOption(t *testing.T) {
 	require.Equal(t, "POST", sms.calls[0].method)
 	require.Equal(t, "/responses", sms.calls[0].path)
 	require.Equal(t, "resp_prev_456", sms.calls[0].body["previous_response_id"])
+}
+
+func TestResponsesStream_TruncatedWithoutResponseCompleted(t *testing.T) {
+	t.Parallel()
+
+	// Truncated Responses stream: deltas without response.completed.
+	chunks := []string{
+		"event: response.created\n" +
+			`data: {"type":"response.created","response":{"id":"resp_01","status":"in_progress"}}` + "\n\n",
+		"event: response.output_item.added\n" +
+			`data: {"type":"response.output_item.added","output_index":0,"item":{"type":"message","id":"msg_01","role":"assistant","status":"in_progress","content":[]}}` + "\n\n",
+		"event: response.output_text.delta\n" +
+			`data: {"type":"response.output_text.delta","output_index":0,"content_index":0,"delta":"Hello"}` + "\n\n",
+	}
+
+	sms := newStreamingMockServer()
+	defer sms.close()
+	sms.chunks = chunks
+
+	model := newResponsesProvider(t, sms.server.URL)
+
+	stream, err := model.Stream(context.Background(), fantasy.Call{
+		Prompt: testPrompt,
+	})
+	require.NoError(t, err)
+
+	var parts []fantasy.StreamPart
+	stream(func(part fantasy.StreamPart) bool {
+		parts = append(parts, part)
+		return true
+	})
+
+	var errPart *fantasy.StreamPart
+	for i, part := range parts {
+		if part.Type == fantasy.StreamPartTypeError {
+			errPart = &parts[i]
+		}
+		require.NotEqual(t, fantasy.StreamPartTypeFinish, part.Type)
+	}
+	require.NotNil(t, errPart)
+
+	var providerErr *fantasy.ProviderError
+	require.ErrorAs(t, errPart.Error, &providerErr)
+	require.True(t, providerErr.IsRetryable())
+	require.ErrorIs(t, providerErr.Cause, io.ErrUnexpectedEOF)
 }

--- a/providers/openai/responses_language_model.go
+++ b/providers/openai/responses_language_model.go
@@ -1240,6 +1240,16 @@ func (o responsesLanguageModel) Stream(ctx context.Context, call fantasy.Call) (
 			return
 		}
 
+		// Truncated stream: no response.completed / response.incomplete event
+		// before close. Surface as a retryable error.
+		if finishReason == fantasy.FinishReasonUnknown {
+			yield(fantasy.StreamPart{
+				Type:  fantasy.StreamPartTypeError,
+				Error: fantasy.NewIncompleteStreamError(),
+			})
+			return
+		}
+
 		yield(fantasy.StreamPart{
 			Type:             fantasy.StreamPartTypeFinish,
 			Usage:            usage,


### PR DESCRIPTION
This should, in theory, make it easier to understand when requests should be retried.