### PR TITLE
feat(openai-compat): add support for reasoning level "max"

### DIFF
--- a/providers/openai/language_model_hooks.go
+++ b/providers/openai/language_model_hooks.go
@@ -123,6 +123,8 @@ func DefaultPrepareCallFunc(model fantasy.LanguageModel, params *openai.ChatComp
 			params.ReasoningEffort = shared.ReasoningEffortHigh
 		case ReasoningEffortXHigh:
 			params.ReasoningEffort = shared.ReasoningEffortXhigh
+		case ReasoningEffortMax:
+			params.ReasoningEffort = shared.ReasoningEffort("max")
 		default:
 			return nil, fmt.Errorf("reasoning model `%s` not supported", *providerOptions.ReasoningEffort)
 		}

--- a/providers/openai/provider_options.go
+++ b/providers/openai/provider_options.go
@@ -24,6 +24,8 @@ const (
 	ReasoningEffortHigh ReasoningEffort = "high"
 	// ReasoningEffortXHigh represents extra-high reasoning effort.
 	ReasoningEffortXHigh ReasoningEffort = "xhigh"
+	// ReasoningEffortMax represents extra-high reasoning effort.
+	ReasoningEffortMax ReasoningEffort = "max"
 )
 
 // Global type identifiers for OpenAI-specific provider data.

--- a/providers/openaicompat/language_model_hooks.go
+++ b/providers/openaicompat/language_model_hooks.go
@@ -39,6 +39,8 @@ func PrepareCallFunc(model fantasy.LanguageModel, params *openaisdk.ChatCompleti
 			params.ReasoningEffort = shared.ReasoningEffortHigh
 		case openai.ReasoningEffortXHigh:
 			params.ReasoningEffort = shared.ReasoningEffortXhigh
+		case openai.ReasoningEffortMax:
+			params.ReasoningEffort = shared.ReasoningEffort("max")
 		default:
 			return nil, fmt.Errorf("reasoning model `%s` not supported", *providerOptions.ReasoningEffort)
 		}


### PR DESCRIPTION
This can be used for DeepSeek:

* https://github.com/charmbracelet/catwalk/pull/271