### PR TITLE
fix(anthropic): preserve web search error replay

### DIFF
--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -1027,8 +1027,9 @@ func toPrompt(prompt fantasy.Prompt, sendReasoningData bool) ([]anthropic.TextBl
 							continue
 						}
 						if result.ProviderExecuted {
-							// Reconstruct web_search_tool_result block
-							// with encrypted_content for round-tripping.
+							// Reconstruct web_search_tool_result blocks,
+							// including encrypted content and errors, for
+							// round-tripping.
 							searchMeta := &WebSearchResultMetadata{}
 							if webMeta, ok := result.ProviderOptions[Name]; ok {
 								if typed, ok := webMeta.(*WebSearchResultMetadata); ok {
@@ -1124,24 +1125,37 @@ func decodeToolCallInputAny(toolCall fantasy.ToolCallPart) (any, *fantasy.CallWa
 // buildWebSearchToolResultBlock constructs an Anthropic
 // web_search_tool_result content block from structured metadata.
 func buildWebSearchToolResultBlock(toolCallID string, searchMeta *WebSearchResultMetadata) anthropic.ContentBlockParamUnion {
-	resultBlocks := make([]anthropic.WebSearchResultBlockParam, 0, len(searchMeta.Results))
-	for _, r := range searchMeta.Results {
-		block := anthropic.WebSearchResultBlockParam{
-			URL:              r.URL,
-			Title:            r.Title,
-			EncryptedContent: r.EncryptedContent,
+	var content anthropic.WebSearchToolResultBlockParamContentUnion
+	switch {
+	case searchMeta != nil && len(searchMeta.Results) > 0:
+		resultBlocks := make([]anthropic.WebSearchResultBlockParam, 0, len(searchMeta.Results))
+		for _, r := range searchMeta.Results {
+			block := anthropic.WebSearchResultBlockParam{
+				URL:              r.URL,
+				Title:            r.Title,
+				EncryptedContent: r.EncryptedContent,
+			}
+			if r.PageAge != "" {
+				block.PageAge = param.NewOpt(r.PageAge)
+			}
+			resultBlocks = append(resultBlocks, block)
 		}
-		if r.PageAge != "" {
-			block.PageAge = param.NewOpt(r.PageAge)
+		content = anthropic.WebSearchToolResultBlockParamContentUnion{
+			OfWebSearchToolResultBlockItem: resultBlocks,
 		}
-		resultBlocks = append(resultBlocks, block)
+	case searchMeta != nil && searchMeta.ErrorCode != "":
+		content = anthropic.NewWebSearchToolRequestError(
+			anthropic.WebSearchToolResultErrorCode(searchMeta.ErrorCode),
+		)
+	default:
+		content = anthropic.WebSearchToolResultBlockParamContentUnion{
+			OfWebSearchToolResultBlockItem: []anthropic.WebSearchResultBlockParam{},
+		}
 	}
 	return anthropic.ContentBlockParamUnion{
 		OfWebSearchToolResult: &anthropic.WebSearchToolResultBlockParam{
 			ToolUseID: toolCallID,
-			Content: anthropic.WebSearchToolResultBlockParamContentUnion{
-				OfWebSearchToolResultBlockItem: resultBlocks,
-			},
+			Content:   content,
 		},
 	}
 }
@@ -1269,6 +1283,12 @@ func (a languageModel) Generate(ctx context.Context, call fantasy.Call) (*fantas
 				toolResult.ProviderMetadata = fantasy.ProviderMetadata{
 					Name: &WebSearchResultMetadata{
 						Results: metadataResults,
+					},
+				}
+			} else if webSearchResult.Content.ErrorCode != "" {
+				toolResult.ProviderMetadata = fantasy.ProviderMetadata{
+					Name: &WebSearchResultMetadata{
+						ErrorCode: string(webSearchResult.Content.ErrorCode),
 					},
 				}
 			}
@@ -1449,6 +1469,12 @@ func (a languageModel) Stream(ctx context.Context, call fantasy.Call) (fantasy.S
 						providerMeta = fantasy.ProviderMetadata{
 							Name: &WebSearchResultMetadata{
 								Results: metadataResults,
+							},
+						}
+					} else if contentBlock.Content.ErrorCode != "" {
+						providerMeta = fantasy.ProviderMetadata{
+							Name: &WebSearchResultMetadata{
+								ErrorCode: string(contentBlock.Content.ErrorCode),
 							},
 						}
 					}

--- a/providers/anthropic/anthropic_test.go
+++ b/providers/anthropic/anthropic_test.go
@@ -670,6 +670,17 @@ func awaitAnthropicCall(t *testing.T, calls <-chan anthropicCall) anthropicCall 
 	}
 }
 
+func requireWebSearchResultMetadata(t *testing.T, metadata fantasy.ProviderMetadata) *WebSearchResultMetadata {
+	t.Helper()
+
+	providerOption, ok := fantasy.ProviderOptions(metadata)[Name]
+	require.True(t, ok, "provider metadata should contain anthropic key")
+	result, ok := providerOption.(*WebSearchResultMetadata)
+	require.True(t, ok, "provider metadata should be *WebSearchResultMetadata")
+	require.NotNil(t, result)
+	return result
+}
+
 func assertNoAnthropicCall(t *testing.T, calls <-chan anthropicCall) {
 	t.Helper()
 
@@ -784,6 +795,103 @@ func mockAnthropicWebSearchResponse() map[string]any {
 			},
 		},
 	}
+}
+
+func mockAnthropicWebSearchErrorResponse() map[string]any {
+	return map[string]any{
+		"id":    "msg_01WebSearchError",
+		"type":  "message",
+		"role":  "assistant",
+		"model": "claude-sonnet-4-20250514",
+		"content": []any{
+			map[string]any{
+				"type":   "server_tool_use",
+				"id":     "srvtoolu_err",
+				"name":   "web_search",
+				"input":  map[string]any{"query": "latest AI news"},
+				"caller": map[string]any{"type": "direct"},
+			},
+			map[string]any{
+				"type":        "web_search_tool_result",
+				"tool_use_id": "srvtoolu_err",
+				"caller":      map[string]any{"type": "direct"},
+				"content": map[string]any{
+					"type":       "web_search_tool_result_error",
+					"error_code": "max_uses_exceeded",
+				},
+			},
+			map[string]any{
+				"type": "text",
+				"text": "I was unable to search.",
+			},
+		},
+		"stop_reason":   "end_turn",
+		"stop_sequence": nil,
+		"usage": map[string]any{
+			"input_tokens":                100,
+			"output_tokens":               20,
+			"cache_creation_input_tokens": 0,
+			"cache_read_input_tokens":     0,
+			"server_tool_use": map[string]any{
+				"web_search_requests": 1,
+			},
+		},
+	}
+}
+
+func TestToPrompt_WebSearchProviderExecutedErrorRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	prompt := fantasy.Prompt{
+		{
+			Role: fantasy.MessageRoleUser,
+			Content: []fantasy.MessagePart{
+				fantasy.TextPart{Text: "Search for the latest AI news"},
+			},
+		},
+		{
+			Role: fantasy.MessageRoleAssistant,
+			Content: []fantasy.MessagePart{
+				fantasy.ToolCallPart{
+					ToolCallID:       "srvtoolu_err",
+					ToolName:         "web_search",
+					Input:            `{"query":"latest AI news"}`,
+					ProviderExecuted: true,
+				},
+				fantasy.ToolResultPart{
+					ToolCallID:       "srvtoolu_err",
+					ProviderExecuted: true,
+					ProviderOptions: fantasy.ProviderOptions{
+						Name: &WebSearchResultMetadata{ErrorCode: "max_uses_exceeded"},
+					},
+				},
+				fantasy.TextPart{Text: "I was unable to search."},
+			},
+		},
+	}
+
+	_, messages, warnings := toPrompt(prompt, true)
+	require.Empty(t, warnings)
+	require.Len(t, messages, 2)
+
+	assistantMsg := messages[1]
+	require.Len(t, assistantMsg.Content, 3)
+	require.NotNil(t, assistantMsg.Content[0].OfServerToolUse)
+	require.Equal(t, "srvtoolu_err", assistantMsg.Content[0].OfServerToolUse.ID)
+
+	webResult := assistantMsg.Content[1]
+	require.NotNil(t, webResult.OfWebSearchToolResult)
+	require.Equal(t, "srvtoolu_err", webResult.OfWebSearchToolResult.ToolUseID)
+	require.Nil(t, webResult.OfWebSearchToolResult.Content.OfWebSearchToolResultBlockItem)
+	require.NotNil(t, webResult.OfWebSearchToolResult.Content.OfRequestWebSearchToolResultError)
+	require.Equal(
+		t,
+		anthropic.WebSearchToolResultErrorCodeMaxUsesExceeded,
+		webResult.OfWebSearchToolResult.Content.OfRequestWebSearchToolResultError.ErrorCode,
+	)
+
+	require.NotNil(t, assistantMsg.Content[2].OfText)
+	require.Equal(t, "I was unable to search.", assistantMsg.Content[2].OfText.Text)
 }
 
 func TestToPrompt_WebSearchProviderExecutedToolResults(t *testing.T) {
@@ -963,6 +1071,66 @@ func TestGenerate_WebSearchResponse(t *testing.T) {
 		"Based on recent search results, here is the latest AI news.",
 		texts[0].Text,
 	)
+}
+
+func TestGenerate_WebSearchErrorPreservesErrorCode(t *testing.T) {
+	t.Parallel()
+
+	server, calls := newAnthropicJSONServer(mockAnthropicWebSearchErrorResponse())
+	defer server.Close()
+
+	provider, err := New(
+		WithAPIKey("test-api-key"),
+		WithBaseURL(server.URL),
+	)
+	require.NoError(t, err)
+
+	model, err := provider.LanguageModel(context.Background(), "claude-sonnet-4-20250514")
+	require.NoError(t, err)
+
+	resp, err := model.Generate(context.Background(), fantasy.Call{
+		Prompt: testPrompt(),
+		Tools: []fantasy.Tool{
+			WebSearchTool(nil),
+		},
+	})
+	require.NoError(t, err)
+
+	call := awaitAnthropicCall(t, calls)
+	require.Equal(t, "POST", call.method)
+	require.Equal(t, "/v1/messages", call.path)
+
+	var (
+		toolCalls   []fantasy.ToolCallContent
+		sources     []fantasy.SourceContent
+		toolResults []fantasy.ToolResultContent
+		texts       []fantasy.TextContent
+	)
+	for _, c := range resp.Content {
+		switch v := c.(type) {
+		case fantasy.ToolCallContent:
+			toolCalls = append(toolCalls, v)
+		case fantasy.SourceContent:
+			sources = append(sources, v)
+		case fantasy.ToolResultContent:
+			toolResults = append(toolResults, v)
+		case fantasy.TextContent:
+			texts = append(texts, v)
+		}
+	}
+
+	require.Len(t, toolCalls, 1)
+	require.True(t, toolCalls[0].ProviderExecuted)
+	require.Equal(t, "srvtoolu_err", toolCalls[0].ToolCallID)
+	require.Empty(t, sources)
+	require.Len(t, toolResults, 1)
+	require.True(t, toolResults[0].ProviderExecuted)
+	require.Equal(t, "srvtoolu_err", toolResults[0].ToolCallID)
+	webMeta := requireWebSearchResultMetadata(t, toolResults[0].ProviderMetadata)
+	require.Equal(t, "max_uses_exceeded", webMeta.ErrorCode)
+	require.Empty(t, webMeta.Results)
+	require.Len(t, texts, 1)
+	require.Equal(t, "I was unable to search.", texts[0].Text)
 }
 
 func TestGenerate_WebSearchToolInRequest(t *testing.T) {
@@ -1434,6 +1602,75 @@ func TestStream_WebSearchResponse(t *testing.T) {
 	// Text block emits a text delta.
 	require.NotEmpty(t, textDeltas, "should have text deltas")
 	require.Equal(t, "Here are the results.", textDeltas[0].Delta)
+}
+
+func TestStream_WebSearchErrorPreservesErrorCode(t *testing.T) {
+	t.Parallel()
+
+	chunks := []string{
+		"event: message_start\n",
+		`data: {"type":"message_start","message":{"id":"msg_01WebSearchError","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"usage":{"input_tokens":100,"output_tokens":0}}}` + "\n\n",
+		"event: content_block_start\n",
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"server_tool_use","id":"srvtoolu_err","name":"web_search","input":{}}}` + "\n\n",
+		"event: content_block_stop\n",
+		`data: {"type":"content_block_stop","index":0}` + "\n\n",
+		"event: content_block_start\n",
+		`data: {"type":"content_block_start","index":1,"content_block":{"type":"web_search_tool_result","tool_use_id":"srvtoolu_err","content":{"type":"web_search_tool_result_error","error_code":"max_uses_exceeded"}}}` + "\n\n",
+		"event: content_block_stop\n",
+		`data: {"type":"content_block_stop","index":1}` + "\n\n",
+		"event: message_stop\n",
+		`data: {"type":"message_stop"}` + "\n\n",
+	}
+
+	server, calls := newAnthropicStreamingServer(chunks)
+	defer server.Close()
+
+	provider, err := New(
+		WithAPIKey("test-api-key"),
+		WithBaseURL(server.URL),
+	)
+	require.NoError(t, err)
+
+	model, err := provider.LanguageModel(context.Background(), "claude-sonnet-4-20250514")
+	require.NoError(t, err)
+
+	stream, err := model.Stream(context.Background(), fantasy.Call{
+		Prompt: testPrompt(),
+		Tools: []fantasy.Tool{
+			WebSearchTool(nil),
+		},
+	})
+	require.NoError(t, err)
+
+	var parts []fantasy.StreamPart
+	stream(func(part fantasy.StreamPart) bool {
+		parts = append(parts, part)
+		return true
+	})
+
+	_ = awaitAnthropicCall(t, calls)
+
+	var (
+		toolResults []fantasy.StreamPart
+		sourceParts []fantasy.StreamPart
+	)
+	for _, p := range parts {
+		switch p.Type {
+		case fantasy.StreamPartTypeToolResult:
+			toolResults = append(toolResults, p)
+		case fantasy.StreamPartTypeSource:
+			sourceParts = append(sourceParts, p)
+		}
+	}
+
+	require.Len(t, toolResults, 1)
+	require.Empty(t, sourceParts)
+	require.True(t, toolResults[0].ProviderExecuted)
+	require.Equal(t, "srvtoolu_err", toolResults[0].ID)
+	require.Equal(t, "web_search", toolResults[0].ToolCallName)
+	webMeta := requireWebSearchResultMetadata(t, toolResults[0].ProviderMetadata)
+	require.Equal(t, "max_uses_exceeded", webMeta.ErrorCode)
+	require.Empty(t, webMeta.Results)
 }
 
 func TestGenerate_ToolChoiceNone(t *testing.T) {

--- a/providers/anthropic/provider_options.go
+++ b/providers/anthropic/provider_options.go
@@ -159,10 +159,14 @@ type WebSearchResultItem struct {
 }
 
 // WebSearchResultMetadata stores web search results from Anthropic's
-// server-executed web_search tool. The structured data (especially
-// EncryptedContent) must be preserved for multi-turn conversations.
+// server-executed web_search tool. The structured data, especially
+// encrypted content and error codes, must be preserved for multi-turn
+// conversations.
 type WebSearchResultMetadata struct {
-	Results []WebSearchResultItem `json:"results"`
+	Results []WebSearchResultItem `json:"results,omitempty"`
+	// ErrorCode is the Anthropic web_search_tool_result_error.error_code.
+	// At most one of Results or ErrorCode should be non-empty.
+	ErrorCode string `json:"error_code,omitempty"`
 }
 
 // Options implements the ProviderOptions interface.


### PR DESCRIPTION
## Summary

Anthropic's provider-executed `web_search` can return either a normal result array or a `web_search_tool_result_error`. `fantasy` already preserves the success path, but it does not preserve the structured error variant on decode and cannot reconstruct it on the next encode.

That makes replay lossy for assistant turns that contain provider-executed web search errors.

## The bug

Today `providers/anthropic` models replay metadata for provider-executed web search results as only `Results []WebSearchResultItem`.

That works for normal search results, including `encrypted_content`, but it misses valid Anthropic responses like:

```json
{
  "type": "web_search_tool_result",
  "tool_use_id": "srvtoolu_err",
  "content": {
    "type": "web_search_tool_result_error",
    "error_code": "max_uses_exceeded"
  }
}
```

When that response comes back from Anthropic, `fantasy` does not preserve `content.error_code` in either the Generate or Stream decode paths. On the next turn, replay therefore rebuilds a different `web_search_tool_result` block instead of the original error variant.

## Why this breaks

For Anthropic's provider-executed tools, these assistant content blocks are part of the provider-owned transcript. If replay changes a `web_search_tool_result_error` into some other shape, the next request no longer contains the same assistant history that Anthropic originally emitted.

That makes multi-turn conversations lossy at the provider boundary. Downstream applications can persist the `fantasy` content they receive, but they cannot recover an Anthropic-specific block variant once the adapter has already discarded it.

## Why the fix belongs in `fantasy`

The loss happens inside the Anthropic adapter itself, at the layer that translates:

- Anthropic wire blocks into `fantasy` content plus provider metadata
- `fantasy` content plus provider metadata back into Anthropic wire blocks

That translation layer is the right place to preserve provider-specific transcript fidelity. If `fantasy` keeps the structured error payload intact, applications do not need Anthropic-specific repair logic just to continue a conversation safely.

## What this changes

- add `ErrorCode` to `WebSearchResultMetadata`
- decode `web_search_tool_result_error` in both Generate and Stream
- re-encode that metadata back into Anthropic's error block variant
- keep the existing success-path behavior for normal web search results
- add focused coverage for encode, Generate, and Stream replay of the error path

This keeps provider-executed web search replay lossless for both success and error variants.
