### PR TITLE
feat(agent): include accumulated text in OnTextEnd callback

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -215,7 +215,8 @@ type (
 	OnTextDeltaFunc func(id, text string) error
 
 	// OnTextEndFunc is called when text ends.
-	OnTextEndFunc func(id string) error
+	// text is the full accumulated text for this message.
+	OnTextEndFunc func(id, text string) error
 
 	// OnReasoningStartFunc is called when reasoning starts.
 	OnReasoningStartFunc func(id string, reasoning ReasoningContent) error
@@ -1336,15 +1337,17 @@ func (a *agent) processStepStream(ctx context.Context, stream StreamResponse, op
 			}
 
 		case StreamPartTypeTextEnd:
+			var accumulatedText string
 			if text, exists := activeTextContent[part.ID]; exists {
 				stepContent = append(stepContent, TextContent{
 					Text:             text,
 					ProviderMetadata: part.ProviderMetadata,
 				})
 				delete(activeTextContent, part.ID)
+				accumulatedText = text
 			}
 			if opts.OnTextEnd != nil {
-				err := opts.OnTextEnd(part.ID)
+				err := opts.OnTextEnd(part.ID, accumulatedText)
 				if err != nil {
 					return stepExecutionResult{}, err
 				}

--- a/agent_stream_test.go
+++ b/agent_stream_test.go
@@ -155,7 +155,7 @@ func TestStreamingAgentCallbacks(t *testing.T) {
 			callbacks["OnTextDelta"] = true
 			return nil
 		},
-		OnTextEnd: func(id string) error {
+		OnTextEnd: func(id, text string) error {
 			callbacks["OnTextEnd"] = true
 			return nil
 		},


### PR DESCRIPTION
Currently `OnTextEndFunc` receives only the message ID:

```go
OnTextEndFunc func(id string) error
```

Consumers who need the full accumulated text (e.g., to collect or persist completed messages) must buffer all deltas themselves. This duplicates the `activeTextContent` map already maintained internally.

`OnReasoningEndFunc` already passes the full content:

```go
OnReasoningEndFunc func(id string, reasoning ReasoningContent) error
```

This PR adds the accumulated text as a second parameter:

```go
OnTextEndFunc func(id string, text string) error
```

The text is already available at the call site from `activeTextContent[part.ID]`.

## Changes
- `agent.go`: updated `OnTextEndFunc` signature and call site
- `agent_stream_test.go`: updated test callback signature

Fixes #239