### PR TITLE
feat(retry): also retry on network connection errors

### DIFF
--- a/retry.go
+++ b/retry.go
@@ -3,6 +3,7 @@ package fantasy
 import (
 	"context"
 	"errors"
+	"net"
 	"strconv"
 	"time"
 )
@@ -54,6 +55,22 @@ func getRetryDelayInMs(err error, exponentialBackoffDelay time.Duration) time.Du
 // isAbortError checks if the error is a context cancellation error.
 func isAbortError(err error) bool {
 	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+}
+
+// isRetryableError reports whether the error should be retried.
+// It checks for retryable ProviderError and also retries network-level
+// connection errors (DNS failures, TCP timeouts, connection refused, etc.)
+// that never produce an HTTP response and therefore aren't wrapped in ProviderError.
+func isRetryableError(err error) bool {
+	var providerErr *ProviderError
+	if errors.As(err, &providerErr) {
+		return providerErr.IsRetryable()
+	}
+	if isAbortError(err) {
+		return false
+	}
+	var netErr net.Error
+	return errors.As(err, &netErr)
 }
 
 // RetryWithExponentialBackoffRespectingRetryHeaders creates a retry function that retries
@@ -110,9 +127,10 @@ func retryWithExponentialBackoff[T any](ctx context.Context, fn RetryFn[T], opti
 	}
 
 	var providerErr *ProviderError
-	if errors.As(err, &providerErr) && providerErr.IsRetryable() && tryNumber <= options.MaxRetries {
+	if isRetryableError(err) && tryNumber <= options.MaxRetries {
 		delay := getRetryDelayInMs(err, options.InitialDelayIn)
 		if options.OnRetry != nil {
+			errors.As(err, &providerErr)
 			options.OnRetry(providerErr, delay)
 		}
 

--- a/retry.go
+++ b/retry.go
@@ -52,27 +52,6 @@ func getRetryDelayInMs(err error, exponentialBackoffDelay time.Duration) time.Du
 	return exponentialBackoffDelay
 }
 
-// isAbortError checks if the error is a context cancellation error.
-func isAbortError(err error) bool {
-	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
-}
-
-// isRetryableError reports whether the error should be retried.
-// It checks for retryable ProviderError and also retries network-level
-// connection errors (DNS failures, TCP timeouts, connection refused, etc.)
-// that never produce an HTTP response and therefore aren't wrapped in ProviderError.
-func isRetryableError(err error) bool {
-	var providerErr *ProviderError
-	if errors.As(err, &providerErr) {
-		return providerErr.IsRetryable()
-	}
-	if isAbortError(err) {
-		return false
-	}
-	var netErr net.Error
-	return errors.As(err, &netErr)
-}
-
 // RetryWithExponentialBackoffRespectingRetryHeaders creates a retry function that retries
 // a failed operation with exponential backoff, while respecting rate limit headers
 // (retry-after-ms and retry-after) if they are provided and reasonable (0-60 seconds).
@@ -152,4 +131,25 @@ func retryWithExponentialBackoff[T any](ctx context.Context, fn RetryFn[T], opti
 	}
 
 	return zero, &RetryError{newErrors}
+}
+
+// isRetryableError reports whether the error should be retried.
+// It checks for retryable ProviderError and also retries network-level
+// connection errors (DNS failures, TCP timeouts, connection refused, etc.)
+// that never produce an HTTP response and therefore aren't wrapped in ProviderError.
+func isRetryableError(err error) bool {
+	var providerErr *ProviderError
+	if errors.As(err, &providerErr) {
+		return providerErr.IsRetryable()
+	}
+	if isAbortError(err) {
+		return false
+	}
+	var netErr net.Error
+	return errors.As(err, &netErr)
+}
+
+// isAbortError checks if the error is a context cancellation error.
+func isAbortError(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
 }

--- a/retry_test.go
+++ b/retry_test.go
@@ -1,0 +1,145 @@
+package fantasy
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+)
+
+func TestIsRetryableError(t *testing.T) {
+	t.Parallel()
+
+	t.Run("retryable ProviderError", func(t *testing.T) {
+		t.Parallel()
+		err := &ProviderError{
+			StatusCode: 429,
+			Message:    "rate limited",
+		}
+		if !isRetryableError(err) {
+			t.Error("expected retryable ProviderError to be retryable")
+		}
+	})
+
+	t.Run("non-retryable ProviderError", func(t *testing.T) {
+		t.Parallel()
+		err := &ProviderError{
+			StatusCode: 400,
+			Message:    "bad request",
+		}
+		if isRetryableError(err) {
+			t.Error("expected non-retryable ProviderError to not be retryable")
+		}
+	})
+
+	t.Run("net.OpError is retryable", func(t *testing.T) {
+		t.Parallel()
+		err := &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("connection refused")}
+		if !isRetryableError(err) {
+			t.Error("expected net.OpError to be retryable")
+		}
+	})
+
+	t.Run("context.Canceled is not retryable", func(t *testing.T) {
+		t.Parallel()
+		err := context.Canceled
+		if isRetryableError(err) {
+			t.Error("expected context.Canceled to not be retryable")
+		}
+	})
+
+	t.Run("context.DeadlineExceeded is not retryable", func(t *testing.T) {
+		t.Parallel()
+		err := context.DeadlineExceeded
+		if isRetryableError(err) {
+			t.Error("expected context.DeadlineExceeded to not be retryable")
+		}
+	})
+
+	t.Run("generic error is not retryable", func(t *testing.T) {
+		t.Parallel()
+		err := errors.New("something went wrong")
+		if isRetryableError(err) {
+			t.Error("expected generic error to not be retryable")
+		}
+	})
+}
+
+func TestRetryWithExponentialBackoff_ConnectionErrors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("retries on net.OpError", func(t *testing.T) {
+		t.Parallel()
+		attempts := 0
+		opts := RetryOptions{
+			MaxRetries:     2,
+			InitialDelayIn: 1 * time.Millisecond,
+			BackoffFactor:  2.0,
+		}
+
+		retryFn := RetryWithExponentialBackoffRespectingRetryHeaders[int](opts)
+
+		result, err := retryFn(context.Background(), func() (int, error) {
+			attempts++
+			if attempts < 3 {
+				return 0, &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("connection refused")}
+			}
+			return 42, nil
+		})
+
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if result != 42 {
+			t.Fatalf("expected result 42, got %d", result)
+		}
+		if attempts != 3 {
+			t.Fatalf("expected 3 attempts, got %d", attempts)
+		}
+	})
+
+	t.Run("does not retry on context.Canceled", func(t *testing.T) {
+		t.Parallel()
+		attempts := 0
+		opts := RetryOptions{
+			MaxRetries:     2,
+			InitialDelayIn: 1 * time.Millisecond,
+			BackoffFactor:  2.0,
+		}
+
+		retryFn := RetryWithExponentialBackoffRespectingRetryHeaders[int](opts)
+
+		_, err := retryFn(context.Background(), func() (int, error) {
+			attempts++
+			return 0, context.Canceled
+		})
+
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if attempts != 1 {
+			t.Fatalf("expected 1 attempt (no retry), got %d", attempts)
+		}
+	})
+
+	t.Run("returns RetryError when max retries exceeded on connection error", func(t *testing.T) {
+		t.Parallel()
+		opts := RetryOptions{
+			MaxRetries:     2,
+			InitialDelayIn: 1 * time.Millisecond,
+			BackoffFactor:  2.0,
+		}
+
+		retryFn := RetryWithExponentialBackoffRespectingRetryHeaders[int](opts)
+
+		_, err := retryFn(context.Background(), func() (int, error) {
+			return 0, &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("connection refused")}
+		})
+
+		var retryErr *RetryError
+		if !errors.As(err, &retryErr) {
+			t.Fatalf("expected RetryError, got %T: %v", err, err)
+		}
+	})
+}


### PR DESCRIPTION

## Summary

- The retry logic in `retryWithExponentialBackoff` only retried errors wrapped in `*ProviderError` (HTTP-level: 429, 5xx, `io.ErrUnexpectedEOF`)
- Network-level errors (DNS failures, TCP timeouts, connection refused, etc.) surface as raw `net.Error` and were **never retried**, even though they're transient and recoverable
- This means losing internet connectivity mid-session causes an immediate error with no retry — the user must resend their message

## Changes

- Added `isRetryableError()` that checks for `net.Error` in addition to `ProviderError.IsRetryable()`
- Explicitly guards against `context.Canceled`/`context.DeadlineExceeded` (which implement `net.Error` in Go) to preserve the existing abort behavior
- Replaced the retry condition `errors.As(err, &providerErr) && providerErr.IsRetryable()` with `isRetryableError(err)`
- Added `retry_test.go` covering the new behavior

## Test plan

- [x] New unit tests pass: `TestIsRetryableError` and `TestRetryWithExponentialBackoff_ConnectionErrors`
- [ ] Existing provider error tests still pass (no behavior change for HTTP-level errors)
- [ ] Manual test: disconnect from network, send a message, reconnect — should auto-retry

## Example of the bug

User loses internet → gets "connection refused" or "no such host" → error displayed immediately → user must resend. With this fix, the existing exponential backoff (2s → 4s, 2 retries) kicks in automatically.


💘 Generated with Crush