### PR TITLE
fix(bedrock): enforce `us-east-1` as region for bedrock

### DIFF
--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -223,8 +223,6 @@ func (a *provider) LanguageModel(ctx context.Context, modelID string) (fantasy.L
 		)
 	}
 	if a.options.useBedrock {
-		modelID = bedrockPrefixModelWithRegion(modelID)
-
 		if a.options.skipAuth || a.options.apiKey != "" {
 			clientOptions = append(
 				clientOptions,

--- a/providers/anthropic/bedrock.go
+++ b/providers/anthropic/bedrock.go
@@ -1,29 +1,13 @@
 package anthropic
 
 import (
-	"cmp"
-	"os"
-	"strings"
-
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/smithy-go/auth/bearer"
 )
 
 func bedrockBasicAuthConfig(apiKey string) aws.Config {
 	return aws.Config{
-		Region:                  cmp.Or(os.Getenv("AWS_REGION"), "us-east-1"),
+		Region:                  "us-east-1",
 		BearerAuthTokenProvider: bearer.StaticTokenProvider{Token: bearer.Token{Value: apiKey}},
 	}
-}
-
-func bedrockPrefixModelWithRegion(modelID string) string {
-	region := os.Getenv("AWS_REGION")
-	if len(region) < 2 {
-		region = "us-east-1"
-	}
-	prefix := region[:2] + "."
-	if strings.HasPrefix(modelID, prefix) {
-		return modelID
-	}
-	return prefix + modelID
 }

--- a/providertests/bedrock_test.go
+++ b/providertests/bedrock_test.go
@@ -30,7 +30,7 @@ func builderBedrockClaudeSonnet(t *testing.T, r *vcr.Recorder) (fantasy.Language
 	if err != nil {
 		return nil, err
 	}
-	return provider.LanguageModel(t.Context(), "anthropic.claude-sonnet-4-5-20250929-v1:0")
+	return provider.LanguageModel(t.Context(), "us.anthropic.claude-sonnet-4-5-20250929-v1:0")
 }
 
 func builderBedrockClaudeOpus(t *testing.T, r *vcr.Recorder) (fantasy.LanguageModel, error) {
@@ -41,7 +41,7 @@ func builderBedrockClaudeOpus(t *testing.T, r *vcr.Recorder) (fantasy.LanguageMo
 	if err != nil {
 		return nil, err
 	}
-	return provider.LanguageModel(t.Context(), "anthropic.claude-opus-4-6-v1")
+	return provider.LanguageModel(t.Context(), "us.anthropic.claude-opus-4-6-v1")
 }
 
 func builderBedrockClaudeHaiku(t *testing.T, r *vcr.Recorder) (fantasy.LanguageModel, error) {
@@ -52,7 +52,7 @@ func builderBedrockClaudeHaiku(t *testing.T, r *vcr.Recorder) (fantasy.LanguageM
 	if err != nil {
 		return nil, err
 	}
-	return provider.LanguageModel(t.Context(), "anthropic.claude-haiku-4-5-20251001-v1:0")
+	return provider.LanguageModel(t.Context(), "us.anthropic.claude-haiku-4-5-20251001-v1:0")
 }
 
 func buildersBedrockBasicAuth(t *testing.T, r *vcr.Recorder) (fantasy.LanguageModel, error) {
@@ -64,5 +64,5 @@ func buildersBedrockBasicAuth(t *testing.T, r *vcr.Recorder) (fantasy.LanguageMo
 	if err != nil {
 		return nil, err
 	}
-	return provider.LanguageModel(t.Context(), "anthropic.claude-haiku-4-5-20251001-v1:0")
+	return provider.LanguageModel(t.Context(), "us.anthropic.claude-haiku-4-5-20251001-v1:0")
 }


### PR DESCRIPTION
As I understand, this is the only region with access to all models.

Having a fixed region should avoid confusion as some users might have `AWS_REGION` or `AWS_DEFAULT_REGION` set, but other regions won't really work.

* Catwalk PR: https://github.com/charmbracelet/catwalk/pull/289
* Crush PR: https://github.com/charmbracelet/crush/pull/2985
* Closes #189