### PR TITLE
fix(reasoning): if reasoning has ever been enabled loop back in

### DIFF
--- a/providers/openaicompat/language_model_hooks.go
+++ b/providers/openaicompat/language_model_hooks.go
@@ -1,6 +1,7 @@
 package openaicompat
 
 import (
+	"cmp"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -14,6 +15,13 @@ import (
 )
 
 const reasoningStartedCtx = "reasoning_started"
+
+// reasoningContentPlaceholder is sent when a provider requires
+// reasoning_content on every assistant message but the current
+// message has no actual reasoning. DeepSeek and Kimi (Moonshot)
+// reject requests where the field is missing or empty once
+// thinking has been active in the conversation.
+const reasoningContentPlaceholder = " "
 
 // PrepareCallFunc prepares the call for the language model.
 func PrepareCallFunc(model fantasy.LanguageModel, params *openaisdk.ChatCompletionNewParams, call fantasy.Call) ([]fantasy.CallWarning, error) {
@@ -137,7 +145,24 @@ func StreamExtraFunc(chunk openaisdk.ChatCompletionChunk, yield func(fantasy.Str
 // ToPromptFunc converts a fantasy prompt to OpenAI format with reasoning support.
 // It handles fantasy.ContentTypeReasoning in assistant messages by adding the
 // reasoning_content field to the message JSON.
-func ToPromptFunc(prompt fantasy.Prompt, _, _ string) ([]openaisdk.ChatCompletionMessageParamUnion, []fantasy.CallWarning) {
+//
+// By default, reasoning_content is only included on messages that carry actual
+// reasoning text. Use NewToPromptFunc(true) to require reasoning_content on all
+// assistant messages once thinking has been active — needed for DeepSeek and
+// Kimi (Moonshot) which reject requests where the field is missing.
+var ToPromptFunc = NewToPromptFunc(false)
+
+// NewToPromptFunc returns a LanguageModelToPromptFunc. When requireReasoning is
+// true, every assistant message after the first reasoning part will include a
+// reasoning_content field (using reasoningContentPlaceholder when no actual
+// reasoning text is present).
+func NewToPromptFunc(requireReasoning bool) openai.LanguageModelToPromptFunc {
+	return func(prompt fantasy.Prompt, _, _ string) ([]openaisdk.ChatCompletionMessageParamUnion, []fantasy.CallWarning) {
+		return toPrompt(prompt, requireReasoning)
+	}
+}
+
+func toPrompt(prompt fantasy.Prompt, requireReasoning bool) ([]openaisdk.ChatCompletionMessageParamUnion, []fantasy.CallWarning) {
 	var messages []openaisdk.ChatCompletionMessageParamUnion
 	var warnings []fantasy.CallWarning
 	hasReasoning := false
@@ -312,19 +337,6 @@ func ToPromptFunc(prompt fantasy.Prompt, _, _ string) ([]openaisdk.ChatCompletio
 			}
 			messages = append(messages, openaisdk.UserMessage(content))
 		case fantasy.MessageRoleAssistant:
-			// simple assistant message just text content
-			if len(msg.Content) == 1 && msg.Content[0].GetType() == fantasy.ContentTypeText {
-				textPart, ok := fantasy.AsContentType[fantasy.TextPart](msg.Content[0])
-				if !ok {
-					warnings = append(warnings, fantasy.CallWarning{
-						Type:    fantasy.CallWarningTypeOther,
-						Message: "assistant message text part does not have the right type",
-					})
-					continue
-				}
-				messages = append(messages, openaisdk.AssistantMessage(textPart.Text))
-				continue
-			}
 			assistantMsg := openaisdk.ChatCompletionAssistantMessageParam{
 				Role: "assistant",
 			}
@@ -376,12 +388,13 @@ func ToPromptFunc(prompt fantasy.Prompt, _, _ string) ([]openaisdk.ChatCompletio
 						})
 				}
 			}
-			// Add reasoning_content field if present, or if thinking is enabled
-			// and the message has tool calls (some providers like Kimi require
-			// reasoning_content on all assistant messages when thinking is enabled).
-			if reasoningText != "" || (hasReasoning && len(assistantMsg.ToolCalls) > 0) {
+			// Once thinking has been active, all subsequent assistant
+			// messages must carry reasoning_content. DeepSeek and Kimi
+			// reject requests where it's missing from any assistant
+			// message (text-only responses and tool calls alike).
+			if reasoningText != "" || (requireReasoning && hasReasoning) {
 				assistantMsg.SetExtraFields(map[string]any{
-					"reasoning_content": reasoningText,
+					"reasoning_content": cmp.Or(reasoningText, reasoningContentPlaceholder),
 				})
 			}
 			if !hasVisibleCompatAssistantContent(&assistantMsg) {

--- a/providers/openaicompat/openaicompat.go
+++ b/providers/openaicompat/openaicompat.go
@@ -8,10 +8,11 @@ import (
 )
 
 type options struct {
-	openaiOptions        []openai.Option
-	languageModelOptions []openai.LanguageModelOption
-	sdkOptions           []option.RequestOption
-	objectMode           fantasy.ObjectMode
+	openaiOptions           []openai.Option
+	languageModelOptions    []openai.LanguageModelOption
+	sdkOptions              []option.RequestOption
+	objectMode              fantasy.ObjectMode
+	requireReasoningContent bool
 }
 
 const (
@@ -32,7 +33,6 @@ func New(opts ...Option) (fantasy.Provider, error) {
 			openai.WithLanguageModelPrepareCallFunc(PrepareCallFunc),
 			openai.WithLanguageModelStreamExtraFunc(StreamExtraFunc),
 			openai.WithLanguageModelExtraContentFunc(ExtraContentFunc),
-			openai.WithLanguageModelToPromptFunc(ToPromptFunc),
 		},
 		objectMode: fantasy.ObjectModeTool, // Default to tool mode for openai-compat
 	}
@@ -46,6 +46,13 @@ func New(opts ...Option) (fantasy.Provider, error) {
 	if objectMode == fantasy.ObjectModeAuto || objectMode == fantasy.ObjectModeJSON {
 		objectMode = fantasy.ObjectModeTool
 	}
+
+	// Build the ToPromptFunc with the reasoning content requirement.
+	toPromptFn := NewToPromptFunc(providerOptions.requireReasoningContent)
+	providerOptions.languageModelOptions = append(
+		providerOptions.languageModelOptions,
+		openai.WithLanguageModelToPromptFunc(toPromptFn),
+	)
 
 	providerOptions.openaiOptions = append(
 		providerOptions.openaiOptions,
@@ -127,5 +134,15 @@ func WithUseResponsesAPI() Option {
 func WithResponsesAPIFunc(fn func(modelID string) bool) Option {
 	return func(o *options) {
 		o.openaiOptions = append(o.openaiOptions, openai.WithResponsesAPIFunc(fn))
+	}
+}
+
+// WithRequireReasoningContent configures the provider to include
+// reasoning_content on all assistant messages once thinking has been
+// active. Required by DeepSeek and Kimi (Moonshot) which reject
+// requests where the field is missing from any assistant message.
+func WithRequireReasoningContent() Option {
+	return func(o *options) {
+		o.requireReasoningContent = true
 	}
 }

--- a/providers/openaicompat/openaicompat_test.go
+++ b/providers/openaicompat/openaicompat_test.go
@@ -8,6 +8,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func mustGetReasoningContent(t *testing.T, extraFields map[string]any) string {
+	t.Helper()
+	rc, ok := extraFields["reasoning_content"]
+	if !ok {
+		t.Fatal("expected reasoning_content key in extra fields")
+		return ""
+	}
+	s, ok := rc.(string)
+	if !ok {
+		t.Fatalf("expected reasoning_content to be string, got %T", rc)
+		return ""
+	}
+	return s
+}
+
 func TestToPromptFunc_ReasoningContent(t *testing.T) {
 	t.Parallel()
 
@@ -36,7 +51,8 @@ func TestToPromptFunc_ReasoningContent(t *testing.T) {
 			},
 		}
 
-		messages, warnings := ToPromptFunc(prompt, "", "")
+		toPrompt := NewToPromptFunc(true)
+		messages, warnings := toPrompt(prompt, "", "")
 
 		require.Empty(t, warnings)
 		require.Len(t, messages, 3)
@@ -347,7 +363,70 @@ func TestToPromptFunc_DropsEmptyMessages(t *testing.T) {
 		require.Empty(t, warnings)
 	})
 
-	t.Run("should add empty reasoning_content to tool call messages when thinking is enabled", func(t *testing.T) {
+	t.Run("should add reasoning_content to text-only messages after reasoning+tool call", func(t *testing.T) {
+		t.Parallel()
+
+		// When thinking was active earlier in the conversation (especially
+		// a reasoning+tool-call turn), DeepSeek requires reasoning_content
+		// on ALL subsequent assistant messages, including plain text
+		// responses that follow tool results.
+		prompt := fantasy.Prompt{
+			{
+				Role: fantasy.MessageRoleUser,
+				Content: []fantasy.MessagePart{
+					fantasy.TextPart{Text: "read file"},
+				},
+			},
+			{
+				// Reasoning + tool call
+				Role: fantasy.MessageRoleAssistant,
+				Content: []fantasy.MessagePart{
+					fantasy.ReasoningPart{Text: "I will use the view tool."},
+					fantasy.ToolCallPart{
+						ToolCallID: "call_1",
+						ToolName:   "view",
+						Input:      `{"file_path":"/tmp/foo"}`,
+					},
+				},
+			},
+			{
+				Role: fantasy.MessageRoleTool,
+				Content: []fantasy.MessagePart{
+					fantasy.ToolResultPart{
+						ToolCallID: "call_1",
+						Output:     fantasy.ToolResultOutputContentText{Text: "hello"},
+					},
+				},
+			},
+			{
+				// Plain text response — must still have reasoning_content
+				Role: fantasy.MessageRoleAssistant,
+				Content: []fantasy.MessagePart{
+					fantasy.TextPart{Text: "The file says hello."},
+				},
+			},
+		}
+
+		toPrompt := NewToPromptFunc(true)
+		messages, warnings := toPrompt(prompt, "", "")
+
+		require.Empty(t, warnings)
+		require.Len(t, messages, 4)
+
+		// Tool call message should have reasoning_content
+		toolMsg := messages[1].OfAssistant
+		require.NotNil(t, toolMsg)
+		require.NotEmpty(t, toolMsg.ToolCalls)
+		require.Equal(t, "I will use the view tool.", mustGetReasoningContent(t, toolMsg.ExtraFields()), "reasoning_content on tool call message")
+
+		// Text-only follow-up must also have reasoning_content
+		textMsg := messages[3].OfAssistant
+		require.NotNil(t, textMsg)
+		require.Equal(t, "The file says hello.", textMsg.Content.OfString.Value)
+		require.Equal(t, " ", mustGetReasoningContent(t, textMsg.ExtraFields()), "reasoning_content must be a space on text-only follow-up after thinking was active")
+	})
+
+	t.Run("should add placeholder reasoning_content to tool call messages when thinking is enabled", func(t *testing.T) {
 		t.Parallel()
 
 		// When thinking is enabled (reasoning parts exist in history),
@@ -387,19 +466,79 @@ func TestToPromptFunc_DropsEmptyMessages(t *testing.T) {
 			},
 		}
 
-		messages, warnings := ToPromptFunc(prompt, "", "")
+		toPrompt := NewToPromptFunc(true)
+		messages, warnings := toPrompt(prompt, "", "")
 
 		require.Empty(t, warnings)
 		require.Len(t, messages, 4)
 
-		// Tool call message must have reasoning_content (empty) since
-		// thinking is enabled in this conversation
+		// Tool call message must have reasoning_content (space) since
+		// thinking is enabled in this conversation — some providers
+		// reject empty string values
 		msg := messages[3].OfAssistant
 		require.NotNil(t, msg)
 		extraFields := msg.ExtraFields()
 		reasoningContent, hasReasoning := extraFields["reasoning_content"]
 		require.True(t, hasReasoning, "reasoning_content must be present on tool call messages when thinking is enabled")
-		require.Equal(t, "", reasoningContent)
+		require.Equal(t, " ", reasoningContent)
+	})
+
+	t.Run("should not inject reasoning_content when not required", func(t *testing.T) {
+		t.Parallel()
+
+		// Even when reasoning parts exist in history, providers that
+		// don't opt into RequireReasoningContent should not get
+		// placeholder reasoning_content injected on subsequent messages.
+		prompt := fantasy.Prompt{
+			{
+				Role: fantasy.MessageRoleUser,
+				Content: []fantasy.MessagePart{
+					fantasy.TextPart{Text: "think"},
+				},
+			},
+			{
+				Role: fantasy.MessageRoleAssistant,
+				Content: []fantasy.MessagePart{
+					fantasy.ReasoningPart{Text: "thinking..."},
+					fantasy.TextPart{Text: "answer"},
+				},
+			},
+			{
+				Role: fantasy.MessageRoleUser,
+				Content: []fantasy.MessagePart{
+					fantasy.TextPart{Text: "now use a tool"},
+				},
+			},
+			{
+				Role: fantasy.MessageRoleAssistant,
+				Content: []fantasy.MessagePart{
+					fantasy.ToolCallPart{
+						ToolCallID: "call_1",
+						ToolName:   "execute",
+						Input:      `{"cmd":"ls"}`,
+					},
+				},
+			},
+		}
+
+		// Default ToPromptFunc does not require reasoning_content
+		messages, warnings := ToPromptFunc(prompt, "", "")
+
+		require.Empty(t, warnings)
+		require.Len(t, messages, 4)
+
+		// The message with actual reasoning should still have it
+		reasoningMsg := messages[1].OfAssistant
+		require.NotNil(t, reasoningMsg)
+		rc, ok := reasoningMsg.ExtraFields()["reasoning_content"]
+		require.True(t, ok, "message with reasoning part should have reasoning_content")
+		require.Equal(t, "thinking...", rc)
+
+		// Subsequent tool call without reasoning should NOT get placeholder
+		toolMsg := messages[3].OfAssistant
+		require.NotNil(t, toolMsg)
+		_, ok = toolMsg.ExtraFields()["reasoning_content"]
+		require.False(t, ok, "should not get placeholder reasoning_content when not required")
 	})
 
 	t.Run("should drop user messages without visible content", func(t *testing.T) {

--- a/retry_test.go
+++ b/retry_test.go
@@ -87,7 +87,6 @@ func TestRetryWithExponentialBackoff_ConnectionErrors(t *testing.T) {
 			}
 			return 42, nil
 		})
-
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}


### PR DESCRIPTION
should fix https://github.com/charmbracelet/crush/issues/2696; when reasoning is enabled on deepseek or kimi in their openai compat modes if it is then disabled but was ever enabled in the first place, they require reasoning content on all tool calls and messages

Fixes CHARM-1395