### PR TITLE
feat(bedrock): add `WithRegion` option to configure aws region

### DIFF
--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -77,7 +77,8 @@ type options struct {
 	vertexLocation string
 	skipAuth       bool
 
-	useBedrock bool
+	useBedrock    bool
+	bedrockRegion string
 
 	objectMode fantasy.ObjectMode
 }
@@ -139,6 +140,13 @@ func WithSkipAuth(skip bool) Option {
 func WithBedrock() Option {
 	return func(o *options) {
 		o.useBedrock = true
+	}
+}
+
+// WithBedrockRegion sets the AWS region for the Bedrock provider.
+func WithBedrockRegion(region string) Option {
+	return func(o *options) {
+		o.bedrockRegion = region
 	}
 }
 
@@ -226,7 +234,7 @@ func (a *provider) LanguageModel(ctx context.Context, modelID string) (fantasy.L
 		if a.options.skipAuth || a.options.apiKey != "" {
 			clientOptions = append(
 				clientOptions,
-				bedrock.WithConfig(bedrockBasicAuthConfig(a.options.apiKey)),
+				bedrock.WithConfig(bedrockBasicAuthConfig(a.options.apiKey, a.options.bedrockRegion)),
 			)
 		} else {
 			if cfg, err := config.LoadDefaultConfig(ctx); err == nil {

--- a/providers/anthropic/bedrock.go
+++ b/providers/anthropic/bedrock.go
@@ -1,13 +1,15 @@
 package anthropic
 
 import (
+	"cmp"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/smithy-go/auth/bearer"
 )
 
-func bedrockBasicAuthConfig(apiKey string) aws.Config {
+func bedrockBasicAuthConfig(apiKey string, region string) aws.Config {
 	return aws.Config{
-		Region:                  "us-east-1",
+		Region:                  cmp.Or(region, "us-east-1"),
 		BearerAuthTokenProvider: bearer.StaticTokenProvider{Token: bearer.Token{Value: apiKey}},
 	}
 }

--- a/providers/bedrock/bedrock.go
+++ b/providers/bedrock/bedrock.go
@@ -78,3 +78,10 @@ func WithSkipAuth(skipAuth bool) Option {
 		o.skipAuth = skipAuth
 	}
 }
+
+// WithRegion sets the AWS region for the Bedrock provider.
+func WithRegion(region string) Option {
+	return func(o *options) {
+		o.anthropicOptions = append(o.anthropicOptions, anthropic.WithBedrockRegion(region))
+	}
+}


### PR DESCRIPTION
* Crush PR: https://github.com/charmbracelet/crush/pull/3016
* Catwalk PR: https://github.com/charmbracelet/catwalk/pull/298

---

Allow users to specify a custom AWS region for Bedrock instead of defaulting to us-east-1, enabling support for EU and other regions.

💘 Generated with Crush

Assisted-by: Crush:qwen3.7-max