### PR TITLE
feat(errors): support ionet context length error

### DIFF
--- a/providers/openai/error.go
+++ b/providers/openai/error.go
@@ -13,7 +13,7 @@ import (
 	"github.com/charmbracelet/openai-go"
 )
 
-var openaiContextPattern = regexp.MustCompile(`maximum context length is (\d+) tokens.*?(?:resulted in|requested) (\d+) tokens`)
+var openaiContextPattern = regexp.MustCompile(`maximum context length (?:is|of) (\d+) tokens.*?(?:resulted in|requested) ~?(\d+) tokens`)
 
 func toProviderErr(err error) error {
 	var apiErr *openai.Error

--- a/providers/openai/openai_test.go
+++ b/providers/openai/openai_test.go
@@ -3665,6 +3665,13 @@ func TestParseContextTooLargeError(t *testing.T) {
 			wantMax:  8192,
 		},
 		{
+			name:     "matches ionet format with of and tilde",
+			message:  "Your request exceeds this model's maximum context length of 204800 tokens. You requested ~269722 tokens (204186 input + 65536 output). Reduce your prompt length or max_tokens and retry.",
+			wantErr:  true,
+			wantUsed: 269722,
+			wantMax:  204800,
+		},
+		{
 			name:    "does not match unrelated error",
 			message: "invalid api key",
 			wantErr: false,


### PR DESCRIPTION
matches the slightly different ionet error message:

```text
Your request exceeds this model's maximum context length of 204800 tokens. You requested ~269722 tokens (204186 input + 65536 output). Reduce your prompt length or max_tokens and retry.
```

fixes: CHARM-1440