### PR TITLE
fix(bedrock): apply region if given for aws config as well

### DIFF
--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -238,6 +238,7 @@ func (a *provider) LanguageModel(ctx context.Context, modelID string) (fantasy.L
 			)
 		} else {
 			if cfg, err := config.LoadDefaultConfig(ctx); err == nil {
+				cfg.Region = cmp.Or(a.options.bedrockRegion, cfg.Region)
 				clientOptions = append(
 					clientOptions,
 					bedrock.WithConfig(cfg),


### PR DESCRIPTION
Before, it was only being applied for raw API keys.