### PR TITLE
fix(anthropic): send thinking display

### DIFF
--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -51,7 +51,7 @@ func thinkingDisplay(providerOptions *ProviderOptions, modelID string) (Thinking
 
 func defaultsToAdaptiveThinking(model string) bool {
 	model = strings.ToLower(strings.TrimSpace(model))
-	return strings.Contains(model, "claude-mythos-preview")
+	return strings.Contains(model, "claude-mythos-preview") || defaultsToOmittedOpusThinkingDisplay(model)
 }
 
 func setThinkingDisplay(param interface{ SetExtraFields(map[string]any) }, display ThinkingDisplay) {
@@ -60,9 +60,10 @@ func setThinkingDisplay(param interface{ SetExtraFields(map[string]any) }, displ
 
 func defaultsToOmittedThinkingDisplay(model string) bool {
 	model = strings.ToLower(strings.TrimSpace(model))
-	if defaultsToAdaptiveThinking(model) {
-		return true
-	}
+	return defaultsToAdaptiveThinking(model)
+}
+
+func defaultsToOmittedOpusThinkingDisplay(model string) bool {
 	_, suffix, ok := strings.Cut(model, "claude-opus-4-")
 	if !ok {
 		return false

--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -55,6 +55,9 @@ func setThinkingDisplay(param interface{ SetExtraFields(map[string]any) }, displ
 
 func defaultsToOmittedThinkingDisplay(model string) bool {
 	model = strings.ToLower(strings.TrimSpace(model))
+	if strings.Contains(model, "claude-mythos-preview") {
+		return true
+	}
 	_, suffix, ok := strings.Cut(model, "claude-opus-4-")
 	if !ok {
 		return false

--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -391,9 +391,17 @@ func (a languageModel) prepareParams(call fantasy.Call) (
 		if providerOptions.Thinking.BudgetTokens == 0 {
 			return nil, nil, nil, nil, &fantasy.Error{Title: "no budget", Message: "thinking requires budget"}
 		}
-		params.Thinking = anthropic.ThinkingConfigParamOfEnabled(providerOptions.Thinking.BudgetTokens)
-		if display, ok := thinkingDisplay(providerOptions, a.modelID); ok {
-			setThinkingDisplay(params.Thinking.OfEnabled, display)
+		if defaultsToAdaptiveThinking(a.modelID) {
+			adaptive := anthropic.NewThinkingConfigAdaptiveParam()
+			if display, ok := thinkingDisplay(providerOptions, a.modelID); ok {
+				setThinkingDisplay(&adaptive, display)
+			}
+			params.Thinking.OfAdaptive = &adaptive
+		} else {
+			params.Thinking = anthropic.ThinkingConfigParamOfEnabled(providerOptions.Thinking.BudgetTokens)
+			if display, ok := thinkingDisplay(providerOptions, a.modelID); ok {
+				setThinkingDisplay(params.Thinking.OfEnabled, display)
+			}
 		}
 		if call.Temperature != nil {
 			params.Temperature = param.Opt[float64]{}

--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -49,13 +49,18 @@ func thinkingDisplay(providerOptions *ProviderOptions, modelID string) (Thinking
 	return "", false
 }
 
+func defaultsToAdaptiveThinking(model string) bool {
+	model = strings.ToLower(strings.TrimSpace(model))
+	return strings.Contains(model, "claude-mythos-preview")
+}
+
 func setThinkingDisplay(param interface{ SetExtraFields(map[string]any) }, display ThinkingDisplay) {
 	param.SetExtraFields(map[string]any{"display": string(display)})
 }
 
 func defaultsToOmittedThinkingDisplay(model string) bool {
 	model = strings.ToLower(strings.TrimSpace(model))
-	if strings.Contains(model, "claude-mythos-preview") {
+	if defaultsToAdaptiveThinking(model) {
 		return true
 	}
 	_, suffix, ok := strings.Cut(model, "claude-opus-4-")
@@ -414,6 +419,12 @@ func (a languageModel) prepareParams(call fantasy.Call) (
 				Details: "TopK is not supported when thinking is enabled",
 			})
 		}
+	case defaultsToAdaptiveThinking(a.modelID):
+		adaptive := anthropic.NewThinkingConfigAdaptiveParam()
+		if display, ok := thinkingDisplay(providerOptions, a.modelID); ok {
+			setThinkingDisplay(&adaptive, display)
+		}
+		params.Thinking.OfAdaptive = &adaptive
 	}
 
 	if len(call.Tools) > 0 {

--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -51,7 +51,11 @@ func thinkingDisplay(providerOptions *ProviderOptions, modelID string) (Thinking
 
 func defaultsToAdaptiveThinking(model string) bool {
 	model = strings.ToLower(strings.TrimSpace(model))
-	return strings.Contains(model, "claude-mythos-preview") || defaultsToOmittedOpusThinkingDisplay(model)
+	return strings.Contains(model, "claude-mythos-preview")
+}
+
+func requiresAdaptiveThinking(model string) bool {
+	return defaultsToAdaptiveThinking(model) || defaultsToOmittedOpusThinkingDisplay(model)
 }
 
 func setThinkingDisplay(param interface{ SetExtraFields(map[string]any) }, display ThinkingDisplay) {
@@ -60,7 +64,7 @@ func setThinkingDisplay(param interface{ SetExtraFields(map[string]any) }, displ
 
 func defaultsToOmittedThinkingDisplay(model string) bool {
 	model = strings.ToLower(strings.TrimSpace(model))
-	return defaultsToAdaptiveThinking(model)
+	return defaultsToAdaptiveThinking(model) || defaultsToOmittedOpusThinkingDisplay(model)
 }
 
 func defaultsToOmittedOpusThinkingDisplay(model string) bool {
@@ -392,7 +396,7 @@ func (a languageModel) prepareParams(call fantasy.Call) (
 		if providerOptions.Thinking.BudgetTokens == 0 {
 			return nil, nil, nil, nil, &fantasy.Error{Title: "no budget", Message: "thinking requires budget"}
 		}
-		if defaultsToAdaptiveThinking(a.modelID) {
+		if requiresAdaptiveThinking(a.modelID) {
 			adaptive := anthropic.NewThinkingConfigAdaptiveParam()
 			if display, ok := thinkingDisplay(providerOptions, a.modelID); ok {
 				setThinkingDisplay(&adaptive, display)

--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"maps"
 	"math"
+	"strconv"
 	"strings"
 
 	"charm.land/fantasy"
@@ -36,6 +37,38 @@ func betaRequestOptions(flags []string) []option.RequestOption {
 		opts = append(opts, option.WithHeaderAdd("anthropic-beta", flag))
 	}
 	return opts
+}
+
+func thinkingDisplay(providerOptions *ProviderOptions, modelID string) (ThinkingDisplay, bool) {
+	if providerOptions != nil && providerOptions.ThinkingDisplay != nil && *providerOptions.ThinkingDisplay != "" {
+		return *providerOptions.ThinkingDisplay, true
+	}
+	if defaultsToOmittedThinkingDisplay(modelID) {
+		return ThinkingDisplaySummarized, true
+	}
+	return "", false
+}
+
+func setThinkingDisplay(param interface{ SetExtraFields(map[string]any) }, display ThinkingDisplay) {
+	param.SetExtraFields(map[string]any{"display": string(display)})
+}
+
+func defaultsToOmittedThinkingDisplay(model string) bool {
+	model = strings.ToLower(strings.TrimSpace(model))
+	_, suffix, ok := strings.Cut(model, "claude-opus-4-")
+	if !ok {
+		return false
+	}
+
+	versionEnd := 0
+	for versionEnd < len(suffix) && suffix[versionEnd] >= '0' && suffix[versionEnd] <= '9' {
+		versionEnd++
+	}
+	if versionEnd == 0 {
+		return false
+	}
+	minor, err := strconv.Atoi(suffix[:versionEnd])
+	return err == nil && minor >= 7
 }
 
 // buildRequestOptions constructs the common request options shared
@@ -342,12 +375,18 @@ func (a languageModel) prepareParams(call fantasy.Call) (
 			Effort: anthropic.OutputConfigEffort(effort),
 		}
 		adaptive := anthropic.NewThinkingConfigAdaptiveParam()
+		if display, ok := thinkingDisplay(providerOptions, a.modelID); ok {
+			setThinkingDisplay(&adaptive, display)
+		}
 		params.Thinking.OfAdaptive = &adaptive
 	case providerOptions.Thinking != nil:
 		if providerOptions.Thinking.BudgetTokens == 0 {
 			return nil, nil, nil, nil, &fantasy.Error{Title: "no budget", Message: "thinking requires budget"}
 		}
 		params.Thinking = anthropic.ThinkingConfigParamOfEnabled(providerOptions.Thinking.BudgetTokens)
+		if display, ok := thinkingDisplay(providerOptions, a.modelID); ok {
+			setThinkingDisplay(params.Thinking.OfEnabled, display)
+		}
 		if call.Temperature != nil {
 			params.Temperature = param.Opt[float64]{}
 			warnings = append(warnings, fantasy.CallWarning{

--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -64,7 +64,7 @@ func defaultsToOmittedThinkingDisplay(model string) bool {
 	for versionEnd < len(suffix) && suffix[versionEnd] >= '0' && suffix[versionEnd] <= '9' {
 		versionEnd++
 	}
-	if versionEnd == 0 {
+	if versionEnd == 0 || versionEnd > 2 {
 		return false
 	}
 	minor, err := strconv.Atoi(suffix[:versionEnd])

--- a/providers/anthropic/anthropic_test.go
+++ b/providers/anthropic/anthropic_test.go
@@ -783,10 +783,14 @@ func TestDefaultsToOmittedThinkingDisplay(t *testing.T) {
 		model string
 		want  bool
 	}{
+		{name: "opus 4.7 alias", model: "claude-opus-4-7", want: true},
 		{name: "opus 4.7", model: "claude-opus-4-7-20260101", want: true},
 		{name: "opus 4.10", model: "claude-opus-4-10-20260101", want: true},
+		{name: "bedrock opus 4.8 alias", model: "us.anthropic.claude-opus-4-8-v1", want: true},
 		{name: "bedrock opus 4.8", model: "us.anthropic.claude-opus-4-8-20260101-v1:0", want: true},
 		{name: "opus 4.6", model: "claude-opus-4-6-20260101", want: false},
+		{name: "opus 4 date only", model: "claude-opus-4-20250514", want: false},
+		{name: "bedrock opus 4 date only", model: "us.anthropic.claude-opus-4-20250514-v1:0", want: false},
 		{name: "sonnet", model: "claude-sonnet-4-20250514", want: false},
 		{name: "no minor", model: "claude-opus-4", want: false},
 	}

--- a/providers/anthropic/anthropic_test.go
+++ b/providers/anthropic/anthropic_test.go
@@ -788,6 +788,8 @@ func TestDefaultsToOmittedThinkingDisplay(t *testing.T) {
 		{name: "opus 4.10", model: "claude-opus-4-10-20260101", want: true},
 		{name: "bedrock opus 4.8 alias", model: "us.anthropic.claude-opus-4-8-v1", want: true},
 		{name: "bedrock opus 4.8", model: "us.anthropic.claude-opus-4-8-20260101-v1:0", want: true},
+		{name: "mythos preview", model: "claude-mythos-preview", want: true},
+		{name: "bedrock mythos preview", model: "anthropic.claude-mythos-preview", want: true},
 		{name: "opus 4.6", model: "claude-opus-4-6-20260101", want: false},
 		{name: "opus 4 date only", model: "claude-opus-4-20250514", want: false},
 		{name: "bedrock opus 4 date only", model: "us.anthropic.claude-opus-4-20250514-v1:0", want: false},

--- a/providers/anthropic/anthropic_test.go
+++ b/providers/anthropic/anthropic_test.go
@@ -612,6 +612,7 @@ func TestParseOptions_Effort(t *testing.T) {
 		"send_reasoning":            true,
 		"thinking":                  map[string]any{"budget_tokens": int64(2048)},
 		"effort":                    "medium",
+		"thinking_display":          "summarized",
 		"disable_parallel_tool_use": true,
 	})
 	require.NoError(t, err)
@@ -621,6 +622,8 @@ func TestParseOptions_Effort(t *testing.T) {
 	require.Equal(t, int64(2048), options.Thinking.BudgetTokens)
 	require.NotNil(t, options.Effort)
 	require.Equal(t, EffortMedium, *options.Effort)
+	require.NotNil(t, options.ThinkingDisplay)
+	require.Equal(t, ThinkingDisplaySummarized, *options.ThinkingDisplay)
 	require.NotNil(t, options.DisableParallelToolUse)
 	require.True(t, *options.DisableParallelToolUse)
 }
@@ -653,6 +656,148 @@ func TestGenerate_SendsOutputConfigEffort(t *testing.T) {
 	require.Equal(t, "POST", call.method)
 	require.Equal(t, "/v1/messages", call.path)
 	requireAnthropicEffort(t, call.body, EffortMedium)
+}
+
+func TestGenerate_SendsThinkingDisplay(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		model       string
+		options     func() *ProviderOptions
+		wantType    string
+		wantDisplay string
+		wantBudget  int64
+	}{
+		{
+			name:  "explicit display with adaptive thinking",
+			model: "claude-sonnet-4-20250514",
+			options: func() *ProviderOptions {
+				effort := EffortMedium
+				display := ThinkingDisplayOmitted
+				return &ProviderOptions{Effort: &effort, ThinkingDisplay: &display}
+			},
+			wantType:    "adaptive",
+			wantDisplay: "omitted",
+		},
+		{
+			name:  "explicit display with budget thinking",
+			model: "claude-sonnet-4-20250514",
+			options: func() *ProviderOptions {
+				display := ThinkingDisplaySummarized
+				return &ProviderOptions{
+					Thinking:        &ThinkingProviderOption{BudgetTokens: 2048},
+					ThinkingDisplay: &display,
+				}
+			},
+			wantType:    "enabled",
+			wantDisplay: "summarized",
+			wantBudget:  2048,
+		},
+		{
+			name:  "opus models default to summarized display",
+			model: "claude-opus-4-7-20260101",
+			options: func() *ProviderOptions {
+				effort := EffortHigh
+				return &ProviderOptions{Effort: &effort}
+			},
+			wantType:    "adaptive",
+			wantDisplay: "summarized",
+		},
+		{
+			name:  "bedrock opus models default to summarized display",
+			model: "us.anthropic.claude-opus-4-8-20260101-v1:0",
+			options: func() *ProviderOptions {
+				effort := EffortHigh
+				return &ProviderOptions{Effort: &effort}
+			},
+			wantType:    "adaptive",
+			wantDisplay: "summarized",
+		},
+		{
+			name:  "explicit display overrides opus default",
+			model: "claude-opus-4-8-20260101",
+			options: func() *ProviderOptions {
+				effort := EffortHigh
+				display := ThinkingDisplayOmitted
+				return &ProviderOptions{Effort: &effort, ThinkingDisplay: &display}
+			},
+			wantType:    "adaptive",
+			wantDisplay: "omitted",
+		},
+		{
+			name:  "older opus models keep provider default",
+			model: "claude-opus-4-6-20260101",
+			options: func() *ProviderOptions {
+				effort := EffortHigh
+				return &ProviderOptions{Effort: &effort}
+			},
+			wantType: "adaptive",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			server, calls := newAnthropicJSONServer(mockAnthropicGenerateResponse())
+			defer server.Close()
+
+			provider, err := New(
+				WithAPIKey("test-api-key"),
+				WithBaseURL(server.URL),
+			)
+			require.NoError(t, err)
+
+			model, err := provider.LanguageModel(context.Background(), tt.model)
+			require.NoError(t, err)
+
+			_, err = model.Generate(context.Background(), fantasy.Call{
+				Prompt:          testPrompt(),
+				ProviderOptions: NewProviderOptions(tt.options()),
+			})
+			require.NoError(t, err)
+
+			call := awaitAnthropicCall(t, calls)
+			thinking, ok := call.body["thinking"].(map[string]any)
+			require.True(t, ok)
+			require.Equal(t, tt.wantType, thinking["type"])
+			if tt.wantDisplay == "" {
+				require.NotContains(t, thinking, "display")
+			} else {
+				require.Equal(t, tt.wantDisplay, thinking["display"])
+			}
+			if tt.wantBudget != 0 {
+				require.InDelta(t, tt.wantBudget, thinking["budget_tokens"], 0)
+			}
+		})
+	}
+}
+
+func TestDefaultsToOmittedThinkingDisplay(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		model string
+		want  bool
+	}{
+		{name: "opus 4.7", model: "claude-opus-4-7-20260101", want: true},
+		{name: "opus 4.10", model: "claude-opus-4-10-20260101", want: true},
+		{name: "bedrock opus 4.8", model: "us.anthropic.claude-opus-4-8-20260101-v1:0", want: true},
+		{name: "opus 4.6", model: "claude-opus-4-6-20260101", want: false},
+		{name: "sonnet", model: "claude-sonnet-4-20250514", want: false},
+		{name: "no minor", model: "claude-opus-4", want: false},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, defaultsToOmittedThinkingDisplay(tt.model))
+		})
+	}
 }
 
 func TestStream_SendsOutputConfigEffort(t *testing.T) {

--- a/providers/anthropic/anthropic_test.go
+++ b/providers/anthropic/anthropic_test.go
@@ -735,6 +735,15 @@ func TestGenerate_SendsThinkingDisplay(t *testing.T) {
 			wantDisplay: "summarized",
 		},
 		{
+			name:  "opus models use adaptive thinking when budget thinking configured",
+			model: "claude-opus-4-7",
+			options: func() *ProviderOptions {
+				return &ProviderOptions{Thinking: &ThinkingProviderOption{BudgetTokens: 2048}}
+			},
+			wantType:    "adaptive",
+			wantDisplay: "summarized",
+		},
+		{
 			name:  "older opus models keep provider default",
 			model: "claude-opus-4-6-20260101",
 			options: func() *ProviderOptions {

--- a/providers/anthropic/anthropic_test.go
+++ b/providers/anthropic/anthropic_test.go
@@ -726,6 +726,15 @@ func TestGenerate_SendsThinkingDisplay(t *testing.T) {
 			wantDisplay: "omitted",
 		},
 		{
+			name:  "mythos models default to adaptive thinking",
+			model: "claude-mythos-preview",
+			options: func() *ProviderOptions {
+				return &ProviderOptions{}
+			},
+			wantType:    "adaptive",
+			wantDisplay: "summarized",
+		},
+		{
 			name:  "older opus models keep provider default",
 			model: "claude-opus-4-6-20260101",
 			options: func() *ProviderOptions {

--- a/providers/anthropic/anthropic_test.go
+++ b/providers/anthropic/anthropic_test.go
@@ -793,6 +793,28 @@ func TestGenerate_SendsThinkingDisplay(t *testing.T) {
 	}
 }
 
+func TestGenerate_DoesNotEnableThinkingForPlainOpus(t *testing.T) {
+	t.Parallel()
+
+	server, calls := newAnthropicJSONServer(mockAnthropicGenerateResponse())
+	defer server.Close()
+
+	provider, err := New(
+		WithAPIKey("test-api-key"),
+		WithBaseURL(server.URL),
+	)
+	require.NoError(t, err)
+
+	model, err := provider.LanguageModel(context.Background(), "claude-opus-4-7")
+	require.NoError(t, err)
+
+	_, err = model.Generate(context.Background(), fantasy.Call{Prompt: testPrompt()})
+	require.NoError(t, err)
+
+	call := awaitAnthropicCall(t, calls)
+	require.NotContains(t, call.body, "thinking")
+}
+
 func TestDefaultsToOmittedThinkingDisplay(t *testing.T) {
 	t.Parallel()
 

--- a/providers/anthropic/provider_options.go
+++ b/providers/anthropic/provider_options.go
@@ -25,6 +25,16 @@ const (
 	EffortMax Effort = "max"
 )
 
+// ThinkingDisplay controls whether Anthropic returns visible thinking content.
+type ThinkingDisplay string
+
+const (
+	// ThinkingDisplaySummarized requests visible summarized thinking content.
+	ThinkingDisplaySummarized ThinkingDisplay = "summarized"
+	// ThinkingDisplayOmitted requests hidden thinking content.
+	ThinkingDisplayOmitted ThinkingDisplay = "omitted"
+)
+
 // Global type identifiers for Anthropic-specific provider data.
 const (
 	TypeProviderOptions         = Name + ".options"
@@ -70,6 +80,7 @@ type ProviderOptions struct {
 	SendReasoning          *bool                   `json:"send_reasoning"`
 	Thinking               *ThinkingProviderOption `json:"thinking"`
 	Effort                 *Effort                 `json:"effort"`
+	ThinkingDisplay        *ThinkingDisplay        `json:"thinking_display"`
 	DisableParallelToolUse *bool                   `json:"disable_parallel_tool_use"`
 	ExtraBody              map[string]any          `json:"extra_body,omitempty"`
 }


### PR DESCRIPTION
## Summary

- Adds a typed Anthropic `ThinkingDisplay` provider option with `summarized` and `omitted` values.
- Sends `thinking.display` for adaptive thinking and budget-token thinking, defaulting omitted-display models to `summarized` when thinking is enabled.
- Converts budget-token thinking on adaptive-only models to adaptive thinking, while preserving plain Opus 4.7+ calls without a `thinking` field.

## Tests

- `go test ./... -count=1 -timeout=30m`
- `GOTOOLCHAIN=go1.26.4 govulncheck ./...`
- `GOTOOLCHAIN=go1.26.4 /home/coder/.mux-tmp/bin/golangci-lint run ./...`

> Mux working on behalf of Mike.
