### PR TITLE
feat(openai): add max reasoning effort

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.25
 	github.com/aws/smithy-go v1.27.2
 	github.com/charmbracelet/anthropic-sdk-go v0.0.0-20260223140439-63879b0b8dab
-	github.com/charmbracelet/openai-go v0.0.0-20260319145158-d0740cc34266
+	github.com/charmbracelet/openai-go v0.0.0-20260617131321-5e4b9c18c4be
 	github.com/charmbracelet/x/exp/slice v0.0.0-20250904123553-b4e2667e5ad5
 	github.com/charmbracelet/x/exp/strings v0.1.0
 	github.com/charmbracelet/x/json v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -88,8 +88,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/charmbracelet/anthropic-sdk-go v0.0.0-20260223140439-63879b0b8dab h1:J7XQLgl9sefgTnTGrmX3xqvp5o6MCiBzEjGv5igAlc4=
 github.com/charmbracelet/anthropic-sdk-go v0.0.0-20260223140439-63879b0b8dab/go.mod h1:hqlYqR7uPKOKfnNeicUbZp0Ps0GeYFlKYtwh5HGDCx8=
-github.com/charmbracelet/openai-go v0.0.0-20260319145158-d0740cc34266 h1:BW/sZtyd1JyYy0h5adMm3tzpNyL857LWjuTRET6OhpY=
-github.com/charmbracelet/openai-go v0.0.0-20260319145158-d0740cc34266/go.mod h1:1DahUaExbUZx/jD+FNT2PKP4L9rLE5+ZBRuI8mZjd/E=
+github.com/charmbracelet/openai-go v0.0.0-20260617131321-5e4b9c18c4be h1:pg+OWlIkk9HOe/8P5J95aKe2wGDzFUiiyFOUpwR30B4=
+github.com/charmbracelet/openai-go v0.0.0-20260617131321-5e4b9c18c4be/go.mod h1:1DahUaExbUZx/jD+FNT2PKP4L9rLE5+ZBRuI8mZjd/E=
 github.com/charmbracelet/x/exp/slice v0.0.0-20250904123553-b4e2667e5ad5 h1:DTSZxdV9qQagD4iGcAt9RgaRBZtJl01bfKgdLzUzUPI=
 github.com/charmbracelet/x/exp/slice v0.0.0-20250904123553-b4e2667e5ad5/go.mod h1:vI5nDVMWi6veaYH+0Fmvpbe/+cv/iJfMntdh+N0+Tms=
 github.com/charmbracelet/x/exp/strings v0.1.0 h1:i69S2XI7uG1u4NLGeJPSYU++Nmjvpo9nwd6aoEm7gkA=

--- a/providers/openai/language_model_hooks.go
+++ b/providers/openai/language_model_hooks.go
@@ -123,6 +123,8 @@ func DefaultPrepareCallFunc(model fantasy.LanguageModel, params *openai.ChatComp
 			params.ReasoningEffort = shared.ReasoningEffortHigh
 		case ReasoningEffortXHigh:
 			params.ReasoningEffort = shared.ReasoningEffortXhigh
+		case ReasoningEffortMax:
+			params.ReasoningEffort = shared.ReasoningEffortMax
 		default:
 			return nil, fmt.Errorf("reasoning model `%s` not supported", *providerOptions.ReasoningEffort)
 		}

--- a/providers/openai/provider_options.go
+++ b/providers/openai/provider_options.go
@@ -24,6 +24,8 @@ const (
 	ReasoningEffortHigh ReasoningEffort = "high"
 	// ReasoningEffortXHigh represents extra-high reasoning effort.
 	ReasoningEffortXHigh ReasoningEffort = "xhigh"
+	// ReasoningEffortMax represents maximum reasoning effort.
+	ReasoningEffortMax ReasoningEffort = "max"
 )
 
 // Global type identifiers for OpenAI-specific provider data.

--- a/providers/openaicompat/language_model_hooks.go
+++ b/providers/openaicompat/language_model_hooks.go
@@ -39,6 +39,8 @@ func PrepareCallFunc(model fantasy.LanguageModel, params *openaisdk.ChatCompleti
 			params.ReasoningEffort = shared.ReasoningEffortHigh
 		case openai.ReasoningEffortXHigh:
 			params.ReasoningEffort = shared.ReasoningEffortXhigh
+		case openai.ReasoningEffortMax:
+			params.ReasoningEffort = shared.ReasoningEffortMax
 		default:
 			return nil, fmt.Errorf("reasoning model `%s` not supported", *providerOptions.ReasoningEffort)
 		}


### PR DESCRIPTION
Add ReasoningEffortMax constant and handle it in both the openai and openaicompat provider hooks. Without this, models that accept "max" (e.g. GLM-5.2 via Neuralwatt) error with "reasoning model `max` not supported" before the request reaches the API.

Requires the corresponding ReasoningEffortMax constant from https://github.com/charmbracelet/openai-go/pull/1 and will fail linting/building/etc. until that's merged and this is updated to rely on that.

Assisted-by: Crush:glm-5.2

- [ ] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
