### PR TITLE
fix(vercel,openrouter): emit empty ReasoningStart for streaming reasoning

### DIFF
--- a/providers/openrouter/language_model_hooks.go
+++ b/providers/openrouter/language_model_hooks.go
@@ -295,15 +295,24 @@ func languageModelStreamExtra(chunk openaisdk.ChatCompletionChunk, yield func(fa
 
 		currentState.format = detail.Format
 		ctx[reasoningStartedCtx] = currentState
+		if !yield(fantasy.StreamPart{
+			Type:             fantasy.StreamPartTypeReasoningStart,
+			ID:               fmt.Sprintf("%d", inx),
+			ProviderMetadata: metadata,
+		}) {
+			return ctx, false
+		}
 		delta := detail.Summary
 		if xstrings.ContainsAnyOf(detail.Format, "google-gemini", "anthropic-claude") {
 			delta = detail.Text
 		}
+		if delta == "" {
+			return ctx, true
+		}
 		return ctx, yield(fantasy.StreamPart{
-			Type:             fantasy.StreamPartTypeReasoningStart,
-			ID:               fmt.Sprintf("%d", inx),
-			Delta:            delta,
-			ProviderMetadata: metadata,
+			Type:  fantasy.StreamPartTypeReasoningDelta,
+			ID:    fmt.Sprintf("%d", inx),
+			Delta: delta,
 		})
 	}
 	if len(reasoningData.ReasoningDetails) == 0 {

--- a/providers/vercel/language_model_hooks.go
+++ b/providers/vercel/language_model_hooks.go
@@ -336,6 +336,13 @@ func languageModelStreamExtra(chunk openaisdk.ChatCompletionChunk, yield func(fa
 		}
 
 		ctx[reasoningStartedCtx] = currentState
+		if !yield(fantasy.StreamPart{
+			Type:             fantasy.StreamPartTypeReasoningStart,
+			ID:               fmt.Sprintf("%d", inx),
+			ProviderMetadata: metadata,
+		}) {
+			return ctx, false
+		}
 		delta := reasoningData.Reasoning
 		if len(reasoningData.ReasoningDetails) > 0 {
 			detail := reasoningData.ReasoningDetails[0]
@@ -350,11 +357,13 @@ func languageModelStreamExtra(chunk openaisdk.ChatCompletionChunk, yield func(fa
 				delta = detail.Text
 			}
 		}
+		if delta == "" {
+			return ctx, true
+		}
 		return ctx, yield(fantasy.StreamPart{
-			Type:             fantasy.StreamPartTypeReasoningStart,
-			ID:               fmt.Sprintf("%d", inx),
-			Delta:            delta,
-			ProviderMetadata: metadata,
+			Type:  fantasy.StreamPartTypeReasoningDelta,
+			ID:    fmt.Sprintf("%d", inx),
+			Delta: delta,
 		})
 	}
 


### PR DESCRIPTION

ReasoningStart was carrying the first reasoning token in its Delta field, which broke consumers that treat Start as a pure signal (matching TextStart convention). Split into empty Start + separate ReasoningDelta. Encrypted single-shot blocks still use atomic Start+Delta+End since they don't stream.

fixes CHARM-1521