### PR TITLE
fix(openai): make latest azure gpt models work

### DIFF
--- a/providers/openai/language_model.go
+++ b/providers/openai/language_model.go
@@ -600,7 +600,7 @@ func isReasoningModel(modelID string) bool {
 		strings.HasPrefix(modelID, "o3") || strings.Contains(modelID, "-o3") ||
 		strings.HasPrefix(modelID, "o4") || strings.Contains(modelID, "-o4") ||
 		strings.HasPrefix(modelID, "oss") || strings.Contains(modelID, "-oss") ||
-		strings.Contains(modelID, "gpt-5") || strings.Contains(modelID, "gpt-5-chat")
+		strings.Contains(strings.ToLower(modelID), "gpt-5")
 }
 
 func isSearchPreviewModel(modelID string) bool {
@@ -609,13 +609,16 @@ func isSearchPreviewModel(modelID string) bool {
 
 func supportsFlexProcessing(modelID string) bool {
 	return strings.HasPrefix(modelID, "o3") || strings.Contains(modelID, "-o3") ||
-		strings.Contains(modelID, "o4-mini") || strings.Contains(modelID, "gpt-5")
+		strings.Contains(modelID, "o4-mini") ||
+		strings.Contains(strings.ToLower(modelID), "gpt-5")
 }
 
 func supportsPriorityProcessing(modelID string) bool {
-	return strings.Contains(modelID, "gpt-4") || strings.Contains(modelID, "gpt-5") ||
-		strings.Contains(modelID, "gpt-5-mini") || strings.HasPrefix(modelID, "o3") ||
-		strings.Contains(modelID, "-o3") || strings.Contains(modelID, "o4-mini")
+	return strings.Contains(strings.ToLower(modelID), "gpt-4") ||
+		strings.Contains(strings.ToLower(modelID), "gpt-5") ||
+		strings.HasPrefix(modelID, "o3") ||
+		strings.Contains(modelID, "-o3") ||
+		strings.Contains(modelID, "o4-mini")
 }
 
 func toOpenAiTools(tools []fantasy.Tool, toolChoice *fantasy.ToolChoice) (openAiTools []openai.ChatCompletionToolUnionParam, openAiToolChoice *openai.ChatCompletionToolChoiceOptionUnionParam, warnings []fantasy.CallWarning) {

--- a/providers/openai/responses_language_model.go
+++ b/providers/openai/responses_language_model.go
@@ -60,11 +60,11 @@ func getResponsesModelConfig(modelID string) responsesModelConfig {
 		strings.Contains(modelID, "-o3") || strings.Contains(modelID, "o4-mini") ||
 		(strings.Contains(modelID, "gpt-5") && !strings.Contains(modelID, "gpt-5-chat"))
 
-	supportsPriorityProcessing := strings.Contains(modelID, "gpt-4") ||
-		strings.Contains(modelID, "gpt-5-mini") ||
-		(strings.Contains(modelID, "gpt-5") &&
-			!strings.Contains(modelID, "gpt-5-nano") &&
-			!strings.Contains(modelID, "gpt-5-chat")) ||
+	supportsPriorityProcessing := strings.Contains(strings.ToLower(modelID), "gpt-4") ||
+		strings.Contains(strings.ToLower(modelID), "gpt-5-mini") ||
+		(strings.Contains(strings.ToLower(modelID), "gpt-5") &&
+			!strings.Contains(strings.ToLower(modelID), "gpt-5-nano") &&
+			!strings.Contains(strings.ToLower(modelID), "gpt-5-chat")) ||
 		strings.HasPrefix(modelID, "o3") ||
 		strings.Contains(modelID, "-o3") ||
 		strings.Contains(modelID, "o4-mini")
@@ -76,7 +76,7 @@ func getResponsesModelConfig(modelID string) responsesModelConfig {
 		supportsPriorityProcessing: supportsPriorityProcessing,
 	}
 
-	if strings.Contains(modelID, "gpt-5-chat") {
+	if strings.Contains(strings.ToLower(modelID), "gpt-5-chat") {
 		return responsesModelConfig{
 			isReasoningModel:           false,
 			systemMessageMode:          defaults.systemMessageMode,
@@ -90,8 +90,8 @@ func getResponsesModelConfig(modelID string) responsesModelConfig {
 		strings.HasPrefix(modelID, "o3") || strings.Contains(modelID, "-o3") ||
 		strings.HasPrefix(modelID, "o4") || strings.Contains(modelID, "-o4") ||
 		strings.HasPrefix(modelID, "oss") || strings.Contains(modelID, "-oss") ||
-		strings.Contains(modelID, "gpt-5") || strings.Contains(modelID, "codex-") ||
-		strings.Contains(modelID, "computer-use") {
+		strings.Contains(strings.ToLower(modelID), "gpt-5") ||
+		strings.Contains(modelID, "codex-") || strings.Contains(modelID, "computer-use") {
 		if strings.Contains(modelID, "o1-mini") || strings.Contains(modelID, "o1-preview") {
 			return responsesModelConfig{
 				isReasoningModel:           true,

--- a/providers/openai/responses_options.go
+++ b/providers/openai/responses_options.go
@@ -4,6 +4,7 @@ package openai
 import (
 	"encoding/json"
 	"slices"
+	"strings"
 
 	"charm.land/fantasy"
 )
@@ -272,12 +273,16 @@ func ParseResponsesOptions(data map[string]any) (*ResponsesProviderOptions, erro
 
 // IsResponsesModel checks if a model ID is a Responses API model for OpenAI.
 func IsResponsesModel(modelID string) bool {
-	return slices.Contains(responsesModelIDs, modelID)
+	return slices.Contains(responsesModelIDs, modelID) ||
+		strings.Contains(strings.ToLower(modelID), "gpt-4") ||
+		strings.Contains(strings.ToLower(modelID), "gpt-5")
 }
 
 // IsResponsesReasoningModel checks if a model ID is a Responses API reasoning model for OpenAI.
 func IsResponsesReasoningModel(modelID string) bool {
-	return slices.Contains(responsesReasoningModelIDs, modelID)
+	return slices.Contains(responsesReasoningModelIDs, modelID) ||
+		strings.Contains(strings.ToLower(modelID), "gpt-4") ||
+		strings.Contains(strings.ToLower(modelID), "gpt-5")
 }
 
 // SearchContextSize controls how much context window space the


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).

Similar to #76 I need these changes to enable proper handling of reasoning models for the Azure GPT models my provider uses which capitalize GPT in their model names. Without the changes here I get the following error:

```
ERROR  Bad Request

Function tools with reasoning_effort are not supported for my-provider-GPT-5.5 in /v1/chat/completions. Please use
/v1/responses instead.
```