### PR TITLE
fix: include available tool names in "tool not found" errors

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -1122,7 +1122,14 @@ func (a *agent) validateToolCall(toolCall ToolCallContent, availableTools []Agen
 				return nil
 			}
 		}
-		return fmt.Errorf("tool not found: %s", toolCall.ToolName)
+		names := make([]string, 0, len(availableTools)+len(execProviderTools))
+		for _, t := range availableTools {
+			names = append(names, t.Info().Name)
+		}
+		for _, ept := range execProviderTools {
+			names = append(names, ept.GetName())
+		}
+		return fmt.Errorf("tool not found: %s. Available tools: %s", toolCall.ToolName, strings.Join(names, ", "))
 	}
 
 	// Validate JSON parsing


### PR DESCRIPTION
When a model generates an invalid tool name (e.g. Kimi putting call IDs in the function name field), the error message now lists all available tools so the model can self-correct on the next turn.

Assisted-by: Crush:claude-opus-4-6