### PR TITLE
fix(openai): keep parallel tool calls separate while streaming

### DIFF
--- a/providers/openai/language_model.go
+++ b/providers/openai/language_model.go
@@ -380,6 +380,9 @@ func (o languageModel) Stream(ctx context.Context, call fantasy.Call) (fantasy.S
 
 					for _, toolCallDelta := range choice.Delta.ToolCalls {
 						if existingToolCall, ok := toolCalls[toolCallDelta.Index]; ok {
+							if existingToolCall.hasFinished {
+								continue
+							}
 							if toolCallDelta.Function.Arguments != "" {
 								existingToolCall.arguments += toolCallDelta.Function.Arguments
 								if !yield(fantasy.StreamPart{
@@ -406,6 +409,33 @@ func (o languageModel) Stream(ctx context.Context, call fantasy.Call) (fantasy.S
 									Error: &fantasy.Error{Title: "invalid provider response", Message: "expected 'function' type."},
 								})
 								return
+							}
+
+							// A new tool call index means any previously opened
+							// calls are complete. Emit ToolInputEnd for each to
+							// preserve per-call framing during streaming so that
+							// consumers can reconstruct parallel tool calls from
+							// the stream order without buffering. Close them in
+							// index order for deterministic output.
+							priorIndices := make([]int64, 0, len(toolCalls))
+							for idx := range toolCalls {
+								priorIndices = append(priorIndices, idx)
+							}
+							slices.Sort(priorIndices)
+							for _, idx := range priorIndices {
+								tc := toolCalls[idx]
+								if idx >= toolCallDelta.Index || tc.hasFinished {
+									continue
+								}
+								if tc.arguments == "" {
+									tc.arguments = "{}"
+									toolCalls[idx] = tc
+								}
+								if !yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeToolInputEnd, ID: tc.id}) {
+									return
+								}
+								tc.hasFinished = true
+								toolCalls[idx] = tc
 							}
 
 							if !yield(fantasy.StreamPart{
@@ -482,15 +512,14 @@ func (o languageModel) Stream(ctx context.Context, call fantasy.Call) (fantasy.S
 			slices.Sort(indices)
 			for _, idx := range indices {
 				tc := toolCalls[idx]
-				if tc.hasFinished {
-					continue
-				}
-				if tc.arguments == "" {
-					tc.arguments = "{}"
-					toolCalls[idx] = tc
-				}
-				if !yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeToolInputEnd, ID: tc.id}) {
-					return
+				if !tc.hasFinished {
+					if tc.arguments == "" {
+						tc.arguments = "{}"
+						toolCalls[idx] = tc
+					}
+					if !yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeToolInputEnd, ID: tc.id}) {
+						return
+					}
 				}
 				if !yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeToolCall, ID: tc.id, ToolCallName: tc.name, ToolCallInput: tc.arguments}) {
 					return

--- a/providers/openai/openai_test.go
+++ b/providers/openai/openai_test.go
@@ -2288,6 +2288,29 @@ func (sms *streamingMockServer) prepareToolStreamResponse() {
 	sms.chunks = chunks
 }
 
+// prepareParallelToolStreamResponse streams two tool calls (index 0 and
+// index 1) the way OpenAI-compatible providers do: each call's fragments
+// arrive sequentially by index, and finish_reason only comes at the end.
+func (sms *streamingMockServer) prepareParallelToolStreamResponse() {
+	chunk := func(body string) string {
+		return `data: {"id":"chatcmpl-parallel","object":"chat.completion.chunk","created":1711357598,"model":"gpt-3.5-turbo-0125","choices":[{"index":0,"delta":` + body + `,"finish_reason":null}]}` + "\n\n"
+	}
+	chunks := []string{
+		// Tool call 0 (get_weather)
+		chunk(`{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_weather","type":"function","function":{"name":"get_weather","arguments":""}}]}`),
+		chunk(`{"tool_calls":[{"index":0,"function":{"arguments":"{\"city\":"}}]}`),
+		chunk(`{"tool_calls":[{"index":0,"function":{"arguments":"\"NYC\"}"}}]}`),
+		// Tool call 1 (get_time) — appearance of index 1 closes call 0
+		chunk(`{"tool_calls":[{"index":1,"id":"call_time","type":"function","function":{"name":"get_time","arguments":""}}]}`),
+		chunk(`{"tool_calls":[{"index":1,"function":{"arguments":"{\"tz\":"}}]}`),
+		chunk(`{"tool_calls":[{"index":1,"function":{"arguments":"\"EST\"}"}}]}`),
+		`data: {"id":"chatcmpl-parallel","object":"chat.completion.chunk","created":1711357598,"model":"gpt-3.5-turbo-0125","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}` + "\n\n",
+		`data: {"id":"chatcmpl-parallel","object":"chat.completion.chunk","created":1711357598,"model":"gpt-3.5-turbo-0125","choices":[],"usage":{"prompt_tokens":53,"completion_tokens":17,"total_tokens":70}}` + "\n\n",
+		"data: [DONE]\n\n",
+	}
+	sms.chunks = chunks
+}
+
 func (sms *streamingMockServer) prepareMixedContentAndToolStreamResponse() {
 	chunks := []string{
 		// Chunk with both content and tool_calls in the same delta
@@ -2582,6 +2605,82 @@ func TestDoStream(t *testing.T) {
 			fullInput.WriteString(delta)
 		}
 		require.Equal(t, `{"value":"Sparkle Day"}`, fullInput.String())
+	})
+
+	t.Run("should frame parallel tool calls during streaming", func(t *testing.T) {
+		t.Parallel()
+
+		server := newStreamingMockServer()
+		defer server.close()
+
+		server.prepareParallelToolStreamResponse()
+
+		provider, err := New(
+			WithAPIKey("test-api-key"),
+			WithBaseURL(server.server.URL),
+		)
+		require.NoError(t, err)
+		model, _ := provider.LanguageModel(t.Context(), "gpt-3.5-turbo")
+
+		stream, err := model.Stream(context.Background(), fantasy.Call{
+			Prompt: testPrompt,
+			Tools: []fantasy.Tool{
+				fantasy.FunctionTool{Name: "get_weather"},
+				fantasy.FunctionTool{Name: "get_time"},
+			},
+		})
+		require.NoError(t, err)
+
+		parts, err := collectStreamParts(stream)
+		require.NoError(t, err)
+
+		// The framing contract: a tool call must be fully delimited
+		// (Start -> Deltas -> End) before the next one opens. No two calls
+		// may be open at once, and no delta may arrive for an already-ended
+		// call. This is what lets an order/index-keyed consumer reconstruct
+		// parallel calls without buffering the whole stream.
+		var openID string // currently open tool call, "" if none
+		ended := map[string]bool{}
+		seenStart := map[string]bool{}
+		argsByID := map[string]*strings.Builder{}
+		nameByID := map[string]string{}
+		var order []string
+
+		for _, part := range parts {
+			switch part.Type {
+			case fantasy.StreamPartTypeToolInputStart:
+				require.Empty(t, openID,
+					"tool call %s opened while %s still open (interleaved framing)", part.ID, openID)
+				require.False(t, seenStart[part.ID], "duplicate start for %s", part.ID)
+				openID = part.ID
+				seenStart[part.ID] = true
+				nameByID[part.ID] = part.ToolCallName
+				argsByID[part.ID] = &strings.Builder{}
+				order = append(order, part.ID)
+			case fantasy.StreamPartTypeToolInputDelta:
+				require.Equal(t, openID, part.ID,
+					"delta for %s but open call is %q", part.ID, openID)
+				require.False(t, ended[part.ID], "delta after end for %s", part.ID)
+				argsByID[part.ID].WriteString(part.Delta)
+			case fantasy.StreamPartTypeToolInputEnd:
+				require.Equal(t, openID, part.ID,
+					"end for %s but open call is %q", part.ID, openID)
+				ended[part.ID] = true
+				openID = ""
+			case fantasy.StreamPartTypeToolCall:
+				require.True(t, ended[part.ID], "tool call %s finalized before end", part.ID)
+				nameByID[part.ID] = part.ToolCallName
+				argsByID[part.ID].Reset()
+				argsByID[part.ID].WriteString(part.ToolCallInput)
+			}
+		}
+
+		require.Equal(t, []string{"call_weather", "call_time"}, order,
+			"expected two distinct calls framed in order")
+		require.Equal(t, "get_weather", nameByID["call_weather"])
+		require.JSONEq(t, `{"city":"NYC"}`, argsByID["call_weather"].String())
+		require.Equal(t, "get_time", nameByID["call_time"])
+		require.JSONEq(t, `{"tz":"EST"}`, argsByID["call_time"].String())
 	})
 
 	t.Run("should handle mixed content and tool calls in same chunk", func(t *testing.T) {


### PR DESCRIPTION
## What happened

When a model returns more than one tool call in a single turn, the OpenAI streaming path stopped emitting per-call boundaries while the response was in flight. The argument fragments of distinct calls interleaved with nothing to separate them, so any consumer reconstructing tool calls from the live stream merged them into one. The merged arguments were invalid JSON, which the provider rejected on the *next* turn. Reproduced reliably with GLM 5.2 on Fireworks.

This was a regression from the end-of-stream finalization change in v0.33.0 (#289), which fixed premature truncation but dropped the streaming delimiters in the process.

## The fix

- Emit each tool call's end-of-input as soon as the next call begins, restoring the `start -> deltas -> end` framing per call that existed before v0.33.0.
- Restore the guard that ignores stray fragments for an already-completed call.
- Close pending calls in a deterministic order.

The set of finalized tool calls emitted at end-of-stream is unchanged, so non-streaming consumers and single-tool-call turns behave exactly as before. This is a bugfix, not a behavior change for correct consumers.

## Tests

Adds a streaming test with two parallel tool calls that asserts each is fully delimited before the next opens. Verified it fails without the fix (calls interleave) and passes with it.