### PR TITLE
feat: unauthorized hook

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -175,7 +175,14 @@ type AgentCall struct {
 	Headers          map[string]string
 	ProviderOptions  ProviderOptions
 	OnRetry          OnRetryCallback
+	OnAuthRefresh    OnAuthRefreshFunc
 	MaxRetries       *int
+
+	// ModelProvider, when non-nil, is called on each retry attempt to
+	// obtain the language model. This allows callers to swap in a
+	// refreshed model after OnAuthRefresh rebuilds credentials. When
+	// nil, the model captured at step preparation time is used.
+	ModelProvider func() LanguageModel
 
 	StopWhen       []StopCondition
 	PrepareStep    PrepareStepFunction
@@ -201,6 +208,16 @@ type (
 
 	// OnErrorFunc is called when an error occurs.
 	OnErrorFunc func(error)
+
+	// OnAuthRefreshFunc is called when a stream fails with an authentication
+	// error that the caller may be able to resolve (e.g. an expired SSO
+	// session or OAuth token). The function should perform whatever credential
+	// refresh is needed and return nil on success, in which case fantasy
+	// retries the operation transparently. Returning an error surfaces the
+	// original auth error to the caller without retry. Pair this with
+	// ModelProvider to supply a rebuilt model carrying the refreshed
+	// credentials on the retry attempt.
+	OnAuthRefreshFunc func(ctx context.Context, err *ProviderError) error
 )
 
 // Stream part callbacks - called for each corresponding stream part type.
@@ -267,7 +284,14 @@ type AgentStreamCall struct {
 	Headers          map[string]string
 	ProviderOptions  ProviderOptions
 	OnRetry          OnRetryCallback
+	OnAuthRefresh    OnAuthRefreshFunc
 	MaxRetries       *int
+
+	// ModelProvider, when non-nil, is called on each retry attempt to
+	// obtain the language model. This allows callers to swap in a
+	// refreshed model after OnAuthRefresh rebuilds credentials. When
+	// nil, the model captured at step preparation time is used.
+	ModelProvider func() LanguageModel
 
 	StopWhen       []StopCondition
 	PrepareStep    PrepareStepFunction
@@ -491,9 +515,17 @@ func (a *agent) Generate(ctx context.Context, opts AgentCall) (*AgentResult, err
 			retryOptions.MaxRetries = *opts.MaxRetries
 		}
 		retryOptions.OnRetry = opts.OnRetry
+		retryOptions.OnAuthRefresh = opts.OnAuthRefresh
 		retry := RetryWithExponentialBackoffRespectingRetryHeaders[*Response](retryOptions)
 		result, err := retry(ctx, func() (*Response, error) {
-			return stepModel.Generate(ctx, Call{
+			// Re-read the model on each retry attempt so that
+			// OnAuthRefresh can swap in a model with fresh credentials.
+			retryModel := stepModel
+			if opts.ModelProvider != nil {
+				retryModel = opts.ModelProvider()
+			}
+
+			return retryModel.Generate(ctx, Call{
 				Prompt:           stepInputMessages,
 				MaxOutputTokens:  opts.MaxOutputTokens,
 				Temperature:      opts.Temperature,
@@ -840,6 +872,7 @@ func (a *agent) Stream(ctx context.Context, opts AgentStreamCall) (*AgentResult,
 		ProviderOptions:  opts.ProviderOptions,
 		MaxRetries:       opts.MaxRetries,
 		OnRetry:          opts.OnRetry,
+		OnAuthRefresh:    opts.OnAuthRefresh,
 		StopWhen:         opts.StopWhen,
 		PrepareStep:      opts.PrepareStep,
 		RepairToolCall:   opts.RepairToolCall,
@@ -951,11 +984,19 @@ func (a *agent) Stream(ctx context.Context, opts AgentStreamCall) (*AgentResult,
 			retryOptions.MaxRetries = *call.MaxRetries
 		}
 		retryOptions.OnRetry = call.OnRetry
+		retryOptions.OnAuthRefresh = call.OnAuthRefresh
 		retry := RetryWithExponentialBackoffRespectingRetryHeaders[stepExecutionResult](retryOptions)
 
 		result, err := retry(ctx, func() (stepExecutionResult, error) {
+			// Re-read the model on each retry attempt so that
+			// OnAuthRefresh can swap in a model with fresh credentials.
+			retryModel := stepModel
+			if call.ModelProvider != nil {
+				retryModel = call.ModelProvider()
+			}
+
 			// Create the stream
-			stream, err := stepModel.Stream(ctx, streamCall)
+			stream, err := retryModel.Stream(ctx, streamCall)
 			if err != nil {
 				return stepExecutionResult{}, err
 			}

--- a/retry.go
+++ b/retry.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net"
+	"net/http"
 	"strconv"
 	"time"
 )
@@ -55,8 +56,25 @@ func getRetryDelayInMs(err error, exponentialBackoffDelay time.Duration) time.Du
 // RetryWithExponentialBackoffRespectingRetryHeaders creates a retry function that retries
 // a failed operation with exponential backoff, while respecting rate limit headers
 // (retry-after-ms and retry-after) if they are provided and reasonable (0-60 seconds).
+//
+// When OnAuthRefresh is set and the operation ends in an authentication error,
+// the hook is given one chance to refresh credentials. On success the entire
+// retry pass runs again with a fresh budget; on failure the original auth
+// error is returned. At most one refresh is attempted, so a credential that
+// stays invalid cannot spin.
 func RetryWithExponentialBackoffRespectingRetryHeaders[T any](options RetryOptions) RetryFunction[T] {
 	return func(ctx context.Context, fn RetryFn[T]) (T, error) {
+		result, err := retryWithExponentialBackoff(ctx, fn, options, nil)
+		if err == nil || options.OnAuthRefresh == nil {
+			return result, err
+		}
+		var authErr *ProviderError
+		if !errors.As(err, &authErr) || !isAuthError(authErr) {
+			return result, err
+		}
+		if refreshErr := options.OnAuthRefresh(ctx, authErr); refreshErr != nil {
+			return result, err // refresh failed: surface the original auth error
+		}
 		return retryWithExponentialBackoff(ctx, fn, options, nil)
 	}
 }
@@ -67,12 +85,20 @@ type RetryOptions struct {
 	InitialDelayIn time.Duration
 	BackoffFactor  float64
 	OnRetry        OnRetryCallback
+
+	// OnAuthRefresh is called when an operation fails with an authentication
+	// error the caller may be able to resolve (e.g. an expired SSO session).
+	// If it returns nil, the entire retry pass restarts with a fresh retry
+	// budget; if it returns an error, the original auth error is returned
+	// without retry. At most one refresh is attempted, since auth refresh is
+	// a one-shot human-in-the-loop step and a second attempt would not fare
+	// better.
+	OnAuthRefresh OnAuthRefreshFunc
 }
 
 // OnRetryCallback defines a function that is called when a retry occurs.
 type OnRetryCallback = func(err *ProviderError, delay time.Duration)
 
-// DefaultRetryOptions returns the default retry options.
 // DefaultRetryOptions returns the default retry options.
 func DefaultRetryOptions() RetryOptions {
 	return RetryOptions{
@@ -131,6 +157,12 @@ func retryWithExponentialBackoff[T any](ctx context.Context, fn RetryFn[T], opti
 	}
 
 	return zero, &RetryError{newErrors}
+}
+
+// isAuthError reports whether the error is an authentication failure that a
+// caller-supplied OnAuthRefresh hook may be able to resolve.
+func isAuthError(err *ProviderError) bool {
+	return err.StatusCode == http.StatusUnauthorized
 }
 
 // isRetryableError reports whether the error should be retried.

--- a/retry_test.go
+++ b/retry_test.go
@@ -142,3 +142,174 @@ func TestRetryWithExponentialBackoff_ConnectionErrors(t *testing.T) {
 		}
 	})
 }
+
+func TestRetryWithAuthRefresh(t *testing.T) {
+	t.Parallel()
+
+	authErr := func() error { return &ProviderError{StatusCode: 401, Message: "unauthorized"} }
+
+	t.Run("refreshes and retries transparently on 401", func(t *testing.T) {
+		t.Parallel()
+		attempts := 0
+		refreshed := 0
+		opts := RetryOptions{
+			MaxRetries:     2,
+			InitialDelayIn: 1 * time.Millisecond,
+			BackoffFactor:  2.0,
+			OnAuthRefresh: func(_ context.Context, _ *ProviderError) error {
+				refreshed++
+				return nil
+			},
+		}
+
+		retryFn := RetryWithExponentialBackoffRespectingRetryHeaders[int](opts)
+		result, err := retryFn(context.Background(), func() (int, error) {
+			attempts++
+			if attempts == 1 {
+				return 0, authErr()
+			}
+			return 7, nil
+		})
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if result != 7 {
+			t.Fatalf("expected result 7, got %d", result)
+		}
+		if refreshed != 1 {
+			t.Fatalf("expected 1 refresh, got %d", refreshed)
+		}
+		if attempts != 2 {
+			t.Fatalf("expected 2 attempts, got %d", attempts)
+		}
+	})
+
+	t.Run("returns original error when refresh fails", func(t *testing.T) {
+		t.Parallel()
+		attempts := 0
+		opts := RetryOptions{
+			MaxRetries:     2,
+			InitialDelayIn: 1 * time.Millisecond,
+			BackoffFactor:  2.0,
+			OnAuthRefresh: func(_ context.Context, _ *ProviderError) error {
+				return errors.New("login canceled")
+			},
+		}
+
+		retryFn := RetryWithExponentialBackoffRespectingRetryHeaders[int](opts)
+		_, err := retryFn(context.Background(), func() (int, error) {
+			attempts++
+			return 0, authErr()
+		})
+
+		var providerErr *ProviderError
+		if !errors.As(err, &providerErr) || providerErr.StatusCode != 401 {
+			t.Fatalf("expected original 401 ProviderError, got %T: %v", err, err)
+		}
+		if attempts != 1 {
+			t.Fatalf("expected 1 attempt (no retry after failed refresh), got %d", attempts)
+		}
+	})
+
+	t.Run("attempts at most one refresh", func(t *testing.T) {
+		t.Parallel()
+		attempts := 0
+		refreshed := 0
+		opts := RetryOptions{
+			MaxRetries:     2,
+			InitialDelayIn: 1 * time.Millisecond,
+			BackoffFactor:  2.0,
+			OnAuthRefresh: func(_ context.Context, _ *ProviderError) error {
+				refreshed++
+				return nil
+			},
+		}
+
+		retryFn := RetryWithExponentialBackoffRespectingRetryHeaders[int](opts)
+		_, err := retryFn(context.Background(), func() (int, error) {
+			attempts++
+			return 0, authErr()
+		})
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if refreshed != 1 {
+			t.Fatalf("expected exactly 1 refresh, got %d", refreshed)
+		}
+		// 1 initial + 1 retry after refresh = 2 attempts.
+		if attempts != 2 {
+			t.Fatalf("expected 2 attempts, got %d", attempts)
+		}
+	})
+
+	t.Run("does not refresh on non-auth errors", func(t *testing.T) {
+		t.Parallel()
+		refreshed := 0
+		opts := RetryOptions{
+			MaxRetries:     2,
+			InitialDelayIn: 1 * time.Millisecond,
+			BackoffFactor:  2.0,
+			OnAuthRefresh: func(_ context.Context, _ *ProviderError) error {
+				refreshed++
+				return nil
+			},
+		}
+
+		retryFn := RetryWithExponentialBackoffRespectingRetryHeaders[int](opts)
+		_, _ = retryFn(context.Background(), func() (int, error) {
+			return 0, &ProviderError{StatusCode: 429, Message: "rate limited"}
+		})
+		if refreshed != 0 {
+			t.Fatalf("expected no refresh on 429, got %d", refreshed)
+		}
+	})
+
+	t.Run("auth retry does not consume general retry budget", func(t *testing.T) {
+		t.Parallel()
+		attempts := 0
+		opts := RetryOptions{
+			MaxRetries:     2,
+			InitialDelayIn: 1 * time.Millisecond,
+			BackoffFactor:  2.0,
+			OnAuthRefresh: func(_ context.Context, _ *ProviderError) error {
+				return nil
+			},
+		}
+
+		retryFn := RetryWithExponentialBackoffRespectingRetryHeaders[int](opts)
+		result, err := retryFn(context.Background(), func() (int, error) {
+			attempts++
+			switch attempts {
+			case 1:
+				return 0, authErr() // resolved via refresh, not the retry budget
+			case 2, 3:
+				return 0, &ProviderError{StatusCode: 500, Message: "server error"}
+			default:
+				return 99, nil
+			}
+		})
+		if err != nil {
+			t.Fatalf("expected success after auth refresh + 2 transport retries, got %v", err)
+		}
+		if result != 99 {
+			t.Fatalf("expected result 99, got %d", result)
+		}
+		if attempts != 4 {
+			t.Fatalf("expected 4 attempts, got %d", attempts)
+		}
+	})
+}
+
+func TestIsAuthError(t *testing.T) {
+	t.Parallel()
+
+	if !isAuthError(&ProviderError{StatusCode: 401}) {
+		t.Error("expected 401 to be an auth error")
+	}
+	if isAuthError(&ProviderError{StatusCode: 403}) {
+		t.Error("expected 403 to not be an auth error")
+	}
+	if isAuthError(&ProviderError{StatusCode: 500}) {
+		t.Error("expected 500 to not be an auth error")
+	}
+}


### PR DESCRIPTION
Adds an opt-in `OnAuthRefresh` hook to the agent and retry layer. When a request fails with an authentication error (HTTP 401), the hook gets one chance to refresh credentials. If it succeeds, the request is retried transparently within the same call; if it fails, the original auth error is returned.

https://github.com/charmbracelet/crush/pull/3193 is the crush side integration

fixes CHARM-1676