### PR TITLE
fix(google): attach thought_signature to FunctionResponse parts

### DIFF
--- a/providers/google/google.go
+++ b/providers/google/google.go
@@ -522,7 +522,24 @@ func toGooglePrompt(prompt fantasy.Prompt, isVertexAI bool) (*genai.Content, []*
 						if isVertexAI {
 							functionResponse.ID = ""
 						}
+						
+						var thoughtSignature []byte
+						for _, m := range prompt {
+							if m.Role == fantasy.MessageRoleAssistant {
+								for _, c := range m.Content {
+									if reasoning, ok := fantasy.AsMessagePart[fantasy.ReasoningPart](c); ok {
+										if md, ok := reasoning.ProviderOptions[Name].(*ReasoningMetadata); ok {
+											if md.ToolID == result.ToolCallID {
+												thoughtSignature = []byte(md.Signature)
+											}
+										}
+									}
+								}
+							}
+						}
+						
 						parts = append(parts, &genai.Part{
+							ThoughtSignature: thoughtSignature,
 							FunctionResponse: functionResponse,
 						})
 
@@ -542,7 +559,24 @@ func toGooglePrompt(prompt fantasy.Prompt, isVertexAI bool) (*genai.Content, []*
 						if isVertexAI {
 							functionResponse.ID = ""
 						}
+						
+						var thoughtSignature []byte
+						for _, m := range prompt {
+							if m.Role == fantasy.MessageRoleAssistant {
+								for _, c := range m.Content {
+									if reasoning, ok := fantasy.AsMessagePart[fantasy.ReasoningPart](c); ok {
+										if md, ok := reasoning.ProviderOptions[Name].(*ReasoningMetadata); ok {
+											if md.ToolID == result.ToolCallID {
+												thoughtSignature = []byte(md.Signature)
+											}
+										}
+									}
+								}
+							}
+						}
+						
 						parts = append(parts, &genai.Part{
+							ThoughtSignature: thoughtSignature,
 							FunctionResponse: functionResponse,
 						})
 					}


### PR DESCRIPTION
Gemini models with reasoning enabled return a \`thought_signature\` alongside a \`FunctionCall\`. The Google API enforces that the subsequent \`FunctionResponse\` part must include this same \`thought_signature\`, or it will reject the request with a 400 \`INVALID_ARGUMENT\` (or 400 \`bad request\` on AI Studio).

This patch ensures that when mapping \`MessageRoleTool\` (ToolResults) into \`FunctionResponse\` parts, we search the conversation history for the matching \`ReasoningContent\` block and copy its \`thought_signature\` onto the \`genai.Part\`.

Fixes a crash when using tools with Gemini 3.1 Pro Preview and reasoning enabled.