### PR TITLE
fix(google): prevent parallel tool calls from dropping thought_signature

### DIFF
--- a/providers/google/google.go
+++ b/providers/google/google.go
@@ -1359,12 +1359,15 @@ func (g languageModel) mapResponse(response *genai.GenerateContentResponse, warn
 							if !ok {
 								continue
 							}
-							reasoningContent.ProviderMetadata = fantasy.ProviderMetadata{
-								Name: metadata,
+							// Only use it if it doesn't already have a signature!
+							if reasoningContent.ProviderMetadata == nil || reasoningContent.ProviderMetadata[Name] == nil {
+								reasoningContent.ProviderMetadata = fantasy.ProviderMetadata{
+									Name: metadata,
+								}
+								content[i] = reasoningContent
+								foundReasoning = true
+								break
 							}
-							content[i] = reasoningContent
-							foundReasoning = true
-							break
 						}
 					}
 					if !foundReasoning {


### PR DESCRIPTION
When Gemini models return parallel tool calls with reasoning enabled (e.g. \`gemini-3.1-pro-preview\`), the model returns a \`thought_signature\` alongside the \`FunctionCall\`. The Google API strictly enforces that the subsequent \`FunctionResponse\` part must include this same \`thought_signature\` by validating the echoed history.

There was a bug in \`mapResponse\` where it iterated through the parallel tool calls but blindly overwrote the \`ProviderMetadata\` on the exact same \`ReasoningContent\` block for every tool call. As a result, the first tool call lost its metadata completely, causing its \`thought_signature\` to be omitted when the history was reconstructed for the next API request. This led the Vertex API to immediately reject the request with a \`400 INVALID_ARGUMENT\` (\`Request contains an invalid argument\`).

This patch ensures that \`mapResponse\` only attaches metadata to a \`ReasoningContent\` block if it does not already have a signature, forcing it to append a new \`ReasoningContent\` block for the subsequent parallel tool calls just like the streaming logic correctly does.

Tested and verified that this completely resolves the \`INVALID_ARGUMENT\` error when agents execute parallel tool calls.