### PR TITLE
feat(vercel): add vercel context limit error parsing

### DIFF
--- a/providers/openai/error.go
+++ b/providers/openai/error.go
@@ -16,6 +16,7 @@ import (
 var (
 	openaiContextPattern  = regexp.MustCompile(`maximum context length (?:is|of) (\d+) tokens.*?(?:resulted in|requested) ~?(\d+) tokens`)
 	alibabaContextPattern = regexp.MustCompile(`Range of input length should be \[\d+,\s*(\d+)\]`)
+	vercelContextPattern  = regexp.MustCompile(`Input too long:\s*(\d+)\s*input tokens,\s*limit is\s*(\d+)`)
 )
 
 func toProviderErr(err error) error {
@@ -58,6 +59,12 @@ func parseContextTooLargeError(message string, providerErr *fantasy.ProviderErro
 	if matches := alibabaContextPattern.FindStringSubmatch(message); matches != nil {
 		providerErr.ContextTooLargeErr = true
 		providerErr.ContextMaxTokens, _ = strconv.Atoi(matches[1])
+		return
+	}
+	if matches := vercelContextPattern.FindStringSubmatch(message); matches != nil {
+		providerErr.ContextTooLargeErr = true
+		providerErr.ContextUsedTokens, _ = strconv.Atoi(matches[1])
+		providerErr.ContextMaxTokens, _ = strconv.Atoi(matches[2])
 	}
 }
 

--- a/providers/openai/openai_test.go
+++ b/providers/openai/openai_test.go
@@ -3857,6 +3857,13 @@ func TestParseContextTooLargeError(t *testing.T) {
 			wantMax: 245760,
 		},
 		{
+			name:     "matches vercel format",
+			message:  "Input too long: 518063 input tokens, limit is 262144 for this model",
+			wantErr:  true,
+			wantUsed: 518063,
+			wantMax:  262144,
+		},
+		{
 			name:    "does not match unrelated error",
 			message: "invalid api key",
 			wantErr: false,


### PR DESCRIPTION
Parse "Input too long" errors from Vercel AI Gateway to extract token counts and mark as context-too-large errors.

Assisted-by: Crush:qwen3.7-plus