### PR TITLE
feat: allow attaching extra fields to OpenAI-compatible message content blocks

### DIFF
--- a/providers/openaicompat/language_model_hooks.go
+++ b/providers/openaicompat/language_model_hooks.go
@@ -15,6 +15,23 @@ import (
 
 const reasoningStartedCtx = "reasoning_started"
 
+// buildTextBlock creates a text content block, applying any provider-specific extra
+// fields (e.g. Qwen's cache_control) onto it. Part-level fields override message-level
+// fields. Returns the block and whether any extra fields were applied; when they were,
+// the message content must be serialized in array form.
+func buildTextBlock(text string, partOpts, msgOpts fantasy.ProviderOptions) (*openaisdk.ChatCompletionContentPartTextParam, bool) {
+	block := &openaisdk.ChatCompletionContentPartTextParam{Text: text}
+	fields := getContentExtraFields(partOpts)
+	if len(fields) == 0 {
+		fields = getContentExtraFields(msgOpts)
+	}
+	if len(fields) > 0 {
+		block.SetExtraFields(fields)
+		return block, true
+	}
+	return block, false
+}
+
 // PrepareCallFunc prepares the call for the language model.
 func PrepareCallFunc(model fantasy.LanguageModel, params *openaisdk.ChatCompletionNewParams, call fantasy.Call) ([]fantasy.CallWarning, error) {
 	providerOptions := &ProviderOptions{}
@@ -147,7 +164,9 @@ func ToPromptFunc(prompt fantasy.Prompt, _, _ string) ([]openaisdk.ChatCompletio
 	for _, msg := range prompt {
 		switch msg.Role {
 		case fantasy.MessageRoleSystem:
-			var systemPromptParts []string
+			var blocks []openaisdk.ChatCompletionContentPartTextParam
+			useArrayForm := false
+
 			for _, c := range msg.Content {
 				if c.GetType() != fantasy.ContentTypeText {
 					warnings = append(warnings, fantasy.CallWarning{
@@ -164,22 +183,38 @@ func ToPromptFunc(prompt fantasy.Prompt, _, _ string) ([]openaisdk.ChatCompletio
 					})
 					continue
 				}
-				text := textPart.Text
-				if strings.TrimSpace(text) != "" {
-					systemPromptParts = append(systemPromptParts, textPart.Text)
+				if strings.TrimSpace(textPart.Text) == "" {
+					continue
 				}
+
+				block, hasExtra := buildTextBlock(textPart.Text, textPart.ProviderOptions, msg.ProviderOptions)
+				useArrayForm = useArrayForm || hasExtra
+				blocks = append(blocks, *block)
 			}
-			if len(systemPromptParts) == 0 {
+
+			if len(blocks) == 0 {
 				warnings = append(warnings, fantasy.CallWarning{
 					Type:    fantasy.CallWarningTypeOther,
 					Message: "system prompt has no text parts",
 				})
 				continue
 			}
-			messages = append(messages, openaisdk.SystemMessage(strings.Join(systemPromptParts, "\n")))
+
+			if useArrayForm {
+				messages = append(messages, openaisdk.SystemMessage(blocks))
+			} else {
+				texts := make([]string, len(blocks))
+				for i, b := range blocks {
+					texts[i] = b.Text
+				}
+				messages = append(messages, openaisdk.SystemMessage(strings.Join(texts, "\n")))
+			}
 		case fantasy.MessageRoleUser:
-			// simple user message just text content
-			if len(msg.Content) == 1 && msg.Content[0].GetType() == fantasy.ContentTypeText {
+			// simple user message just text content. Messages carrying extra
+			// content fields fall through to the array path below, which applies
+			// them via buildTextBlock.
+			if len(msg.Content) == 1 && msg.Content[0].GetType() == fantasy.ContentTypeText &&
+				!hasContentExtraFields(msg.Content[0].Options(), msg.ProviderOptions) {
 				textPart, ok := fantasy.AsContentType[fantasy.TextPart](msg.Content[0])
 				if !ok {
 					warnings = append(warnings, fantasy.CallWarning{
@@ -204,10 +239,9 @@ func ToPromptFunc(prompt fantasy.Prompt, _, _ string) ([]openaisdk.ChatCompletio
 						})
 						continue
 					}
+					textBlock, _ := buildTextBlock(textPart.Text, textPart.ProviderOptions, msg.ProviderOptions)
 					content = append(content, openaisdk.ChatCompletionContentPartUnionParam{
-						OfText: &openaisdk.ChatCompletionContentPartTextParam{
-							Text: textPart.Text,
-						},
+						OfText: textBlock,
 					})
 				case fantasy.ContentTypeFile:
 					filePart, ok := fantasy.AsContentType[fantasy.FilePart](c)
@@ -324,7 +358,15 @@ func ToPromptFunc(prompt fantasy.Prompt, _, _ string) ([]openaisdk.ChatCompletio
 					})
 					continue
 				}
-				messages = append(messages, openaisdk.AssistantMessage(textPart.Text))
+				// Extra content fields (e.g. cache_control) require array form.
+				textBlock, hasExtra := buildTextBlock(textPart.Text, textPart.ProviderOptions, msg.ProviderOptions)
+				if hasExtra {
+					messages = append(messages, openaisdk.AssistantMessage([]openaisdk.ChatCompletionAssistantMessageParamContentArrayOfContentPartUnion{
+						{OfText: textBlock},
+					}))
+				} else {
+					messages = append(messages, openaisdk.AssistantMessage(textPart.Text))
+				}
 				continue
 			}
 			assistantMsg := openaisdk.ChatCompletionAssistantMessageParam{
@@ -342,8 +384,17 @@ func ToPromptFunc(prompt fantasy.Prompt, _, _ string) ([]openaisdk.ChatCompletio
 						})
 						continue
 					}
-					assistantMsg.Content = openaisdk.ChatCompletionAssistantMessageParamContentUnion{
-						OfString: param.NewOpt(textPart.Text),
+					textBlock, hasExtra := buildTextBlock(textPart.Text, textPart.ProviderOptions, msg.ProviderOptions)
+					if hasExtra {
+						assistantMsg.Content = openaisdk.ChatCompletionAssistantMessageParamContentUnion{
+							OfArrayOfContentParts: []openaisdk.ChatCompletionAssistantMessageParamContentArrayOfContentPartUnion{
+								{OfText: textBlock},
+							},
+						}
+					} else {
+						assistantMsg.Content = openaisdk.ChatCompletionAssistantMessageParamContentUnion{
+							OfString: param.NewOpt(textPart.Text),
+						}
 					}
 				case fantasy.ContentTypeReasoning:
 					reasoningPart, ok := fantasy.AsContentType[fantasy.ReasoningPart](c)

--- a/providers/openaicompat/openaicompat_test.go
+++ b/providers/openaicompat/openaicompat_test.go
@@ -487,3 +487,366 @@ func TestToPromptFunc_DropsEmptyMessages(t *testing.T) {
 		require.Empty(t, warnings)
 	})
 }
+
+func TestToPromptFunc_ContentExtraFields(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should add cache_control to user message with content array", func(t *testing.T) {
+		t.Parallel()
+
+		prompt := fantasy.Prompt{
+			{
+				Role: fantasy.MessageRoleUser,
+				Content: []fantasy.MessagePart{
+					fantasy.TextPart{
+						Text: "Analyze this document.",
+						ProviderOptions: fantasy.ProviderOptions{
+							Name: &ContentExtraFields{
+								Fields: map[string]any{"cache_control": map[string]string{"type": "ephemeral"}},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		messages, warnings := ToPromptFunc(prompt, "", "")
+
+		require.Empty(t, warnings)
+		require.Len(t, messages, 1)
+
+		msg := messages[0].OfUser
+		require.NotNil(t, msg)
+		// Should use content array format when cache_control is present
+		require.Equal(t, "", msg.Content.OfString.Value)
+		require.NotNil(t, msg.Content.OfArrayOfContentParts)
+		require.Len(t, msg.Content.OfArrayOfContentParts, 1)
+
+		textBlock := msg.Content.OfArrayOfContentParts[0].OfText
+		require.NotNil(t, textBlock)
+		require.Equal(t, "Analyze this document.", textBlock.Text)
+
+		// Check cache_control in extra fields
+		extraFields := textBlock.ExtraFields()
+		cacheControl, hasCacheControl := extraFields["cache_control"]
+		require.True(t, hasCacheControl)
+		cacheMap, ok := cacheControl.(map[string]string)
+		require.True(t, ok)
+		require.Equal(t, "ephemeral", cacheMap["type"])
+	})
+
+	t.Run("should add cache_control to system message with content array", func(t *testing.T) {
+		t.Parallel()
+
+		prompt := fantasy.Prompt{
+			{
+				Role: fantasy.MessageRoleSystem,
+				Content: []fantasy.MessagePart{
+					fantasy.TextPart{
+						Text: "You are a helpful assistant.",
+						ProviderOptions: fantasy.ProviderOptions{
+							Name: &ContentExtraFields{
+								Fields: map[string]any{"cache_control": map[string]string{"type": "ephemeral"}},
+							},
+						},
+					},
+				},
+			},
+			{
+				Role: fantasy.MessageRoleUser,
+				Content: []fantasy.MessagePart{
+					fantasy.TextPart{Text: "Hello"},
+				},
+			},
+		}
+
+		messages, warnings := ToPromptFunc(prompt, "", "")
+
+		require.Empty(t, warnings)
+		require.Len(t, messages, 2)
+
+		systemMsg := messages[0].OfSystem
+		require.NotNil(t, systemMsg)
+		// Should use content array format when cache_control is present
+		require.Equal(t, "", systemMsg.Content.OfString.Value)
+		require.NotNil(t, systemMsg.Content.OfArrayOfContentParts)
+		require.Len(t, systemMsg.Content.OfArrayOfContentParts, 1)
+
+		textBlock := systemMsg.Content.OfArrayOfContentParts[0]
+		require.Equal(t, "You are a helpful assistant.", textBlock.Text)
+
+		// Check cache_control in extra fields
+		extraFields := textBlock.ExtraFields()
+		cacheControl, hasCacheControl := extraFields["cache_control"]
+		require.True(t, hasCacheControl)
+		cacheMap, ok := cacheControl.(map[string]string)
+		require.True(t, ok)
+		require.Equal(t, "ephemeral", cacheMap["type"])
+	})
+
+	t.Run("should add cache_control to assistant message with content array", func(t *testing.T) {
+		t.Parallel()
+
+		prompt := fantasy.Prompt{
+			{
+				Role: fantasy.MessageRoleUser,
+				Content: []fantasy.MessagePart{
+					fantasy.TextPart{Text: "Hello"},
+				},
+			},
+			{
+				Role: fantasy.MessageRoleAssistant,
+				Content: []fantasy.MessagePart{
+					fantasy.TextPart{
+						Text: "Hi there!",
+						ProviderOptions: fantasy.ProviderOptions{
+							Name: &ContentExtraFields{
+								Fields: map[string]any{"cache_control": map[string]string{"type": "ephemeral"}},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		messages, warnings := ToPromptFunc(prompt, "", "")
+
+		require.Empty(t, warnings)
+		require.Len(t, messages, 2)
+
+		assistantMsg := messages[1].OfAssistant
+		require.NotNil(t, assistantMsg)
+		// Should use content array format when cache_control is present
+		require.Equal(t, "", assistantMsg.Content.OfString.Value)
+		require.NotNil(t, assistantMsg.Content.OfArrayOfContentParts)
+		require.Len(t, assistantMsg.Content.OfArrayOfContentParts, 1)
+
+		textBlock := assistantMsg.Content.OfArrayOfContentParts[0].OfText
+		require.NotNil(t, textBlock)
+		require.Equal(t, "Hi there!", textBlock.Text)
+
+		// Check cache_control in extra fields
+		extraFields := textBlock.ExtraFields()
+		cacheControl, hasCacheControl := extraFields["cache_control"]
+		require.True(t, hasCacheControl)
+		cacheMap, ok := cacheControl.(map[string]string)
+		require.True(t, ok)
+		require.Equal(t, "ephemeral", cacheMap["type"])
+	})
+
+	t.Run("should not use content array for messages without cache_control", func(t *testing.T) {
+		t.Parallel()
+
+		prompt := fantasy.Prompt{
+			{
+				Role: fantasy.MessageRoleUser,
+				Content: []fantasy.MessagePart{
+					fantasy.TextPart{Text: "Hello"},
+				},
+			},
+		}
+
+		messages, warnings := ToPromptFunc(prompt, "", "")
+
+		require.Empty(t, warnings)
+		require.Len(t, messages, 1)
+
+		msg := messages[0].OfUser
+		require.NotNil(t, msg)
+		// Should use string format when no cache_control
+		require.NotEqual(t, "", msg.Content.OfString.Value)
+		require.Equal(t, "Hello", msg.Content.OfString.Value)
+		require.Nil(t, msg.Content.OfArrayOfContentParts)
+	})
+
+	t.Run("should handle multiple content parts with mixed cache_control", func(t *testing.T) {
+		t.Parallel()
+
+		prompt := fantasy.Prompt{
+			{
+				Role: fantasy.MessageRoleUser,
+				Content: []fantasy.MessagePart{
+					fantasy.TextPart{Text: "Context: "},
+					fantasy.TextPart{
+						Text: "Large document here...",
+						ProviderOptions: fantasy.ProviderOptions{
+							Name: &ContentExtraFields{
+								Fields: map[string]any{"cache_control": map[string]string{"type": "ephemeral"}},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		messages, warnings := ToPromptFunc(prompt, "", "")
+
+		require.Empty(t, warnings)
+		require.Len(t, messages, 1)
+
+		msg := messages[0].OfUser
+		require.NotNil(t, msg)
+		// Should use content array format since one part has cache_control
+		require.Equal(t, "", msg.Content.OfString.Value)
+		require.NotNil(t, msg.Content.OfArrayOfContentParts)
+		require.Len(t, msg.Content.OfArrayOfContentParts, 2)
+
+		// First part should not have cache_control
+		firstBlock := msg.Content.OfArrayOfContentParts[0].OfText
+		require.NotNil(t, firstBlock)
+		require.Equal(t, "Context: ", firstBlock.Text)
+		require.Empty(t, firstBlock.ExtraFields())
+
+		// Second part should have cache_control
+		secondBlock := msg.Content.OfArrayOfContentParts[1].OfText
+		require.NotNil(t, secondBlock)
+		require.Equal(t, "Large document here...", secondBlock.Text)
+		extraFields := secondBlock.ExtraFields()
+		cacheControl, hasCacheControl := extraFields["cache_control"]
+		require.True(t, hasCacheControl)
+		cacheMap, ok := cacheControl.(map[string]string)
+		require.True(t, ok)
+		require.Equal(t, "ephemeral", cacheMap["type"])
+	})
+
+	t.Run("should fall back to message-level cache_control when part has none", func(t *testing.T) {
+		t.Parallel()
+
+		prompt := fantasy.Prompt{
+			{
+				Role: fantasy.MessageRoleUser,
+				Content: []fantasy.MessagePart{
+					fantasy.TextPart{
+						Text: "Hello",
+						// No cache_control on this part
+					},
+				},
+				// But cache_control on the message itself
+				ProviderOptions: fantasy.ProviderOptions{
+					Name: &ContentExtraFields{
+						Fields: map[string]any{"cache_control": map[string]string{"type": "ephemeral"}},
+					},
+				},
+			},
+		}
+
+		messages, warnings := ToPromptFunc(prompt, "", "")
+
+		require.Empty(t, warnings)
+		require.Len(t, messages, 1)
+
+		msg := messages[0].OfUser
+		require.NotNil(t, msg)
+		// Should use content array format due to message-level cache_control
+		require.Equal(t, "", msg.Content.OfString.Value)
+		require.NotNil(t, msg.Content.OfArrayOfContentParts)
+		require.Len(t, msg.Content.OfArrayOfContentParts, 1)
+
+		textBlock := msg.Content.OfArrayOfContentParts[0].OfText
+		require.NotNil(t, textBlock)
+		require.Equal(t, "Hello", textBlock.Text)
+
+		// Check cache_control in extra fields
+		extraFields := textBlock.ExtraFields()
+		cacheControl, hasCacheControl := extraFields["cache_control"]
+		require.True(t, hasCacheControl)
+		cacheMap, ok := cacheControl.(map[string]string)
+		require.True(t, ok)
+		require.Equal(t, "ephemeral", cacheMap["type"])
+	})
+
+	t.Run("should prefer part-level cache_control over message-level", func(t *testing.T) {
+		t.Parallel()
+
+		prompt := fantasy.Prompt{
+			{
+				Role: fantasy.MessageRoleUser,
+				Content: []fantasy.MessagePart{
+					fantasy.TextPart{
+						Text: "First part",
+						// Part-level cache_control with different type
+						ProviderOptions: fantasy.ProviderOptions{
+							Name: &ContentExtraFields{
+								Fields: map[string]any{"cache_control": map[string]string{"type": "ephemeral"}},
+							},
+						},
+					},
+					fantasy.TextPart{Text: "Second part"}, // No part-level
+				},
+				// Message-level cache_control
+				ProviderOptions: fantasy.ProviderOptions{
+					Name: &ContentExtraFields{
+						Fields: map[string]any{"cache_control": map[string]string{"type": "persistent"}},
+					},
+				},
+			},
+		}
+
+		messages, warnings := ToPromptFunc(prompt, "", "")
+
+		require.Empty(t, warnings)
+		require.Len(t, messages, 1)
+
+		msg := messages[0].OfUser
+		require.NotNil(t, msg)
+		require.NotNil(t, msg.Content.OfArrayOfContentParts)
+		require.Len(t, msg.Content.OfArrayOfContentParts, 2)
+
+		// First part should have ephemeral (part-level wins)
+		firstBlock := msg.Content.OfArrayOfContentParts[0].OfText
+		require.NotNil(t, firstBlock)
+		extraFields := firstBlock.ExtraFields()
+		cacheControl := extraFields["cache_control"].(map[string]string)
+		require.Equal(t, "ephemeral", cacheControl["type"])
+
+		// Second part should have persistent (message-level fallback)
+		secondBlock := msg.Content.OfArrayOfContentParts[1].OfText
+		require.NotNil(t, secondBlock)
+		extraFields = secondBlock.ExtraFields()
+		cacheControl = extraFields["cache_control"].(map[string]string)
+		require.Equal(t, "persistent", cacheControl["type"])
+	})
+
+	t.Run("should add cache_control to multi-part assistant message with tool calls", func(t *testing.T) {
+		t.Parallel()
+
+		prompt := fantasy.Prompt{
+			{
+				Role: fantasy.MessageRoleAssistant,
+				Content: []fantasy.MessagePart{
+					fantasy.TextPart{
+						Text: "Let me check that.",
+						ProviderOptions: fantasy.ProviderOptions{
+							Name: &ContentExtraFields{
+								Fields: map[string]any{"cache_control": map[string]string{"type": "ephemeral"}},
+							},
+						},
+					},
+					fantasy.ToolCallPart{
+						ToolCallID: "call_1",
+						ToolName:   "lookup",
+						Input:      "{}",
+					},
+				},
+			},
+		}
+
+		messages, warnings := ToPromptFunc(prompt, "", "")
+
+		require.Empty(t, warnings)
+		require.Len(t, messages, 1)
+
+		assistantMsg := messages[0].OfAssistant
+		require.NotNil(t, assistantMsg)
+		// Tool calls force the multi-part path; cache_control must still survive.
+		require.Equal(t, "", assistantMsg.Content.OfString.Value)
+		require.Len(t, assistantMsg.Content.OfArrayOfContentParts, 1)
+		require.Len(t, assistantMsg.ToolCalls, 1)
+
+		textBlock := assistantMsg.Content.OfArrayOfContentParts[0].OfText
+		require.NotNil(t, textBlock)
+		require.Equal(t, "Let me check that.", textBlock.Text)
+		cacheControl := textBlock.ExtraFields()["cache_control"].(map[string]string)
+		require.Equal(t, "ephemeral", cacheControl["type"])
+	})
+}

--- a/providers/openaicompat/provider_options.go
+++ b/providers/openaicompat/provider_options.go
@@ -10,13 +10,21 @@ import (
 
 // Global type identifiers for OpenAI-compatible provider data.
 const (
-	TypeProviderOptions = Name + ".options"
+	TypeProviderOptions    = Name + ".options"
+	TypeContentExtraFields = Name + ".content_extra_fields"
 )
 
 // Register OpenAI-compatible provider-specific types with the global registry.
 func init() {
 	fantasy.RegisterProviderType(TypeProviderOptions, func(data []byte) (fantasy.ProviderOptionsData, error) {
 		var v ProviderOptions
+		if err := json.Unmarshal(data, &v); err != nil {
+			return nil, err
+		}
+		return &v, nil
+	})
+	fantasy.RegisterProviderType(TypeContentExtraFields, func(data []byte) (fantasy.ProviderOptionsData, error) {
+		var v ContentExtraFields
 		if err := json.Unmarshal(data, &v); err != nil {
 			return nil, err
 		}
@@ -80,4 +88,74 @@ func ParseOptions(data map[string]any) (*ProviderOptions, error) {
 		return nil, err
 	}
 	return &options, nil
+}
+
+// ContentExtraFields injects non-standard JSON fields onto an individual message
+// content block. It is the content-block analogue of ProviderOptions.ExtraBody
+// (which injects fields onto the request root), and exists to support provider
+// extensions that the OpenAI API format does not model.
+//
+// When a content part carries this option, its content is automatically serialized
+// in array form (rather than as a plain string), and the given fields are merged
+// onto the text block.
+//
+// The primary use case is explicit prompt caching on Alibaba Cloud Qwen 3.6 models,
+// which expect a non-standard cache_control field on cached content blocks:
+//
+//	textPart := fantasy.TextPart{
+//	    Text: "Large system prompt or document (min 1024 tokens)...",
+//	    ProviderOptions: fantasy.ProviderOptions{
+//	        "openai-compat": &openaicompat.ContentExtraFields{
+//	            Fields: map[string]any{
+//	                "cache_control": map[string]string{"type": "ephemeral"},
+//	            },
+//	        },
+//	    },
+//	}
+//
+// Providers that do not recognize the injected fields will ignore them.
+//
+// Note: at the message level this shares a provider-options key with
+// ProviderOptions, so a single message cannot carry both message-level
+// ProviderOptions and message-level ContentExtraFields. Set ContentExtraFields
+// at the content-part level to avoid that conflict.
+type ContentExtraFields struct {
+	Fields map[string]any `json:"fields"`
+}
+
+// Options implements the ProviderOptions interface.
+func (*ContentExtraFields) Options() {}
+
+// MarshalJSON implements custom JSON marshaling with type info for ContentExtraFields.
+func (o ContentExtraFields) MarshalJSON() ([]byte, error) {
+	type plain ContentExtraFields
+	return fantasy.MarshalProviderType(TypeContentExtraFields, plain(o))
+}
+
+// UnmarshalJSON implements custom JSON unmarshaling with type info for ContentExtraFields.
+func (o *ContentExtraFields) UnmarshalJSON(data []byte) error {
+	type plain ContentExtraFields
+	var p plain
+	if err := fantasy.UnmarshalProviderType(data, &p); err != nil {
+		return err
+	}
+	*o = ContentExtraFields(p)
+	return nil
+}
+
+// getContentExtraFields returns the extra content-block fields from provider options,
+// or nil if none are set.
+func getContentExtraFields(providerOptions fantasy.ProviderOptions) map[string]any {
+	if options, ok := providerOptions[Name]; ok {
+		if options, ok := options.(*ContentExtraFields); ok {
+			return options.Fields
+		}
+	}
+	return nil
+}
+
+// hasContentExtraFields reports whether extra content-block fields are present on
+// either the part-level or message-level provider options.
+func hasContentExtraFields(partOpts, msgOpts fantasy.ProviderOptions) bool {
+	return len(getContentExtraFields(partOpts)) > 0 || len(getContentExtraFields(msgOpts)) > 0
 }


### PR DESCRIPTION
Adds a way to attach arbitrary non-standard JSON fields onto individual message content blocks for OpenAI-compatible providers, mirroring the existing root-level extra-body mechanism.

## Example: prompt caching

Using Alibaba caching as an example it can be enabled like this

```go
fantasy.TextPart{
    Text: "Large system prompt or document...",
    ProviderOptions: fantasy.ProviderOptions{
        "openai-compat": &openaicompat.ContentExtraFields{
            Fields: map[string]any{"cache_control": map[string]string{"type": "ephemeral"}},
        },
    },
}
```

Fixes CHARM-1538.