### PR TITLE
http: support per-call HTTP headers

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -172,6 +172,7 @@ type AgentCall struct {
 	FrequencyPenalty *float64    `json:"frequency_penalty"`
 	ActiveTools      []string    `json:"active_tools"`
 	ToolChoice       *ToolChoice `json:"tool_choice"`
+	Headers          map[string]string
 	ProviderOptions  ProviderOptions
 	OnRetry          OnRetryCallback
 	MaxRetries       *int
@@ -402,6 +403,10 @@ func (a *agent) prepareCall(call AgentCall) AgentCall {
 	if a.settings.headers != nil {
 		maps.Copy(headers, a.settings.headers)
 	}
+	if call.Headers != nil {
+		maps.Copy(headers, call.Headers)
+	}
+	call.Headers = headers
 
 	return call
 }
@@ -499,6 +504,7 @@ func (a *agent) Generate(ctx context.Context, opts AgentCall) (*AgentResult, err
 				Tools:            preparedTools,
 				ToolChoice:       &stepToolChoice,
 				UserAgent:        a.settings.userAgent,
+				Headers:          opts.Headers,
 				ProviderOptions:  opts.ProviderOptions,
 			})
 		})
@@ -830,6 +836,7 @@ func (a *agent) Stream(ctx context.Context, opts AgentStreamCall) (*AgentResult,
 		FrequencyPenalty: opts.FrequencyPenalty,
 		ActiveTools:      opts.ActiveTools,
 		ToolChoice:       opts.ToolChoice,
+		Headers:          opts.Headers,
 		ProviderOptions:  opts.ProviderOptions,
 		MaxRetries:       opts.MaxRetries,
 		OnRetry:          opts.OnRetry,
@@ -934,6 +941,7 @@ func (a *agent) Stream(ctx context.Context, opts AgentStreamCall) (*AgentResult,
 			Tools:            preparedTools,
 			ToolChoice:       &stepToolChoice,
 			UserAgent:        a.settings.userAgent,
+			Headers:          call.Headers,
 			ProviderOptions:  call.ProviderOptions,
 		}
 

--- a/model.go
+++ b/model.go
@@ -221,6 +221,9 @@ type Call struct {
 	// UserAgent overrides the provider-level User-Agent header for this call.
 	UserAgent string `json:"-"`
 
+	// Headers overrides matching provider-level headers for this call.
+	Headers map[string]string `json:"-"`
+
 	// for provider specific options, the key is the provider id
 	ProviderOptions ProviderOptions `json:"provider_options"`
 }

--- a/object.go
+++ b/object.go
@@ -44,6 +44,9 @@ type ObjectCall struct {
 	// UserAgent overrides the provider-level User-Agent header for this call.
 	UserAgent string `json:"-"`
 
+	// Headers overrides matching provider-level headers for this call.
+	Headers map[string]string `json:"-"`
+
 	ProviderOptions ProviderOptions
 
 	RepairText schema.ObjectRepairFunc

--- a/object/object.go
+++ b/object/object.go
@@ -121,6 +121,7 @@ func GenerateWithTool(
 		PresencePenalty:  call.PresencePenalty,
 		FrequencyPenalty: call.FrequencyPenalty,
 		UserAgent:        call.UserAgent,
+		Headers:          call.Headers,
 		ProviderOptions:  call.ProviderOptions,
 	})
 	if err != nil {
@@ -214,6 +215,7 @@ func GenerateWithText(
 		PresencePenalty:  call.PresencePenalty,
 		FrequencyPenalty: call.FrequencyPenalty,
 		UserAgent:        call.UserAgent,
+		Headers:          call.Headers,
 		ProviderOptions:  call.ProviderOptions,
 	})
 	if err != nil {
@@ -297,6 +299,7 @@ func StreamWithTool(
 		PresencePenalty:  call.PresencePenalty,
 		FrequencyPenalty: call.FrequencyPenalty,
 		UserAgent:        call.UserAgent,
+		Headers:          call.Headers,
 		ProviderOptions:  call.ProviderOptions,
 	})
 	if err != nil {
@@ -507,6 +510,7 @@ func StreamWithText(
 		PresencePenalty:  call.PresencePenalty,
 		FrequencyPenalty: call.FrequencyPenalty,
 		UserAgent:        call.UserAgent,
+		Headers:          call.Headers,
 		ProviderOptions:  call.ProviderOptions,
 	})
 	if err != nil {

--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -94,6 +94,7 @@ func buildRequestOptions(call fantasy.Call, rawTools []json.RawMessage, betaFlag
 	}
 
 	reqOpts := callUARequestOptions(call)
+	reqOpts = append(reqOpts, callHeadersRequestOptions(call)...)
 	if len(rawTools) > 0 {
 		// Tools are injected as raw JSON rather than via params.Tools
 		// because the SDK doesn't model beta tool types (e.g. computer

--- a/providers/anthropic/call_useragent.go
+++ b/providers/anthropic/call_useragent.go
@@ -12,3 +12,15 @@ func callUARequestOptions(call fantasy.Call) []option.RequestOption {
 	}
 	return nil
 }
+
+func callHeadersRequestOptions(call fantasy.Call) []option.RequestOption {
+	headers, ok := httpheaders.CallHeaders(call.Headers)
+	if !ok {
+		return nil
+	}
+	opts := make([]option.RequestOption, 0, len(headers))
+	for k, v := range headers {
+		opts = append(opts, option.WithHeader(k, v))
+	}
+	return opts
+}

--- a/providers/google/call_useragent.go
+++ b/providers/google/call_useragent.go
@@ -10,16 +10,24 @@ import (
 
 type callUAKey struct{}
 
+type callHeadersKey struct{}
+
 func withCallUA(ctx context.Context, call fantasy.Call) context.Context {
 	if ua, ok := httpheaders.CallUserAgent(call.UserAgent); ok {
-		return context.WithValue(ctx, callUAKey{}, ua)
+		ctx = context.WithValue(ctx, callUAKey{}, ua)
+	}
+	if headers, ok := httpheaders.CallHeaders(call.Headers); ok {
+		ctx = context.WithValue(ctx, callHeadersKey{}, headers)
 	}
 	return ctx
 }
 
 func withObjectCallUA(ctx context.Context, call fantasy.ObjectCall) context.Context {
 	if ua, ok := httpheaders.CallUserAgent(call.UserAgent); ok {
-		return context.WithValue(ctx, callUAKey{}, ua)
+		ctx = context.WithValue(ctx, callUAKey{}, ua)
+	}
+	if headers, ok := httpheaders.CallHeaders(call.Headers); ok {
+		ctx = context.WithValue(ctx, callHeadersKey{}, headers)
 	}
 	return ctx
 }
@@ -48,6 +56,15 @@ func (t *uaTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if ua, ok := req.Context().Value(callUAKey{}).(string); ok && ua != "" {
 		req = req.Clone(req.Context())
 		req.Header.Set("User-Agent", ua)
+	}
+	if headers, ok := req.Context().Value(callHeadersKey{}).(map[string]string); ok && len(headers) > 0 {
+		if req.Header.Get("User-Agent") == "" {
+			// Clone already happened above if UA was set; clone here otherwise.
+			req = req.Clone(req.Context())
+		}
+		for k, v := range headers {
+			req.Header.Set(k, v)
+		}
 	}
 	return t.base.RoundTrip(req)
 }

--- a/providers/internal/httpheaders/httpheaders.go
+++ b/providers/internal/httpheaders/httpheaders.go
@@ -58,3 +58,13 @@ func CallUserAgent(callUA string) (string, bool) {
 	}
 	return "", false
 }
+
+// CallHeaders resolves per-call headers. It returns the headers map and true
+// if per-call headers should be applied, or nil and false if the client-level
+// headers should be used as-is.
+func CallHeaders(headers map[string]string) (map[string]string, bool) {
+	if len(headers) > 0 {
+		return headers, true
+	}
+	return nil, false
+}

--- a/providers/openai/call_useragent.go
+++ b/providers/openai/call_useragent.go
@@ -29,3 +29,27 @@ func objectCallUARequestOptions(call fantasy.ObjectCall) []option.RequestOption 
 	}
 	return nil
 }
+
+func callHeadersRequestOptions(call fantasy.Call) []option.RequestOption {
+	headers, ok := httpheaders.CallHeaders(call.Headers)
+	if !ok {
+		return nil
+	}
+	opts := make([]option.RequestOption, 0, len(headers))
+	for k, v := range headers {
+		opts = append(opts, option.WithHeader(k, v))
+	}
+	return opts
+}
+
+func objectCallHeadersRequestOptions(call fantasy.ObjectCall) []option.RequestOption {
+	headers, ok := httpheaders.CallHeaders(call.Headers)
+	if !ok {
+		return nil
+	}
+	opts := make([]option.RequestOption, 0, len(headers))
+	for k, v := range headers {
+		opts = append(opts, option.WithHeader(k, v))
+	}
+	return opts
+}

--- a/providers/openai/language_model.go
+++ b/providers/openai/language_model.go
@@ -247,7 +247,7 @@ func (o languageModel) Generate(ctx context.Context, call fantasy.Call) (*fantas
 	if err != nil {
 		return nil, err
 	}
-	response, err := o.client.Chat.Completions.New(ctx, *params, callUARequestOptions(call)...)
+	response, err := o.client.Chat.Completions.New(ctx, *params, append(callUARequestOptions(call), callHeadersRequestOptions(call)...)...)
 	if err != nil {
 		return nil, toProviderErr(err)
 	}
@@ -318,7 +318,7 @@ func (o languageModel) Stream(ctx context.Context, call fantasy.Call) (fantasy.S
 		IncludeUsage: openai.Bool(true),
 	}
 
-	stream := o.client.Chat.Completions.NewStreaming(ctx, *params, callUARequestOptions(call)...)
+	stream := o.client.Chat.Completions.NewStreaming(ctx, *params, append(callUARequestOptions(call), callHeadersRequestOptions(call)...)...)
 	isActiveText := false
 	toolCalls := make(map[int64]streamToolCall)
 
@@ -764,7 +764,7 @@ func (o languageModel) generateObjectWithJSONMode(ctx context.Context, call fant
 		},
 	}
 
-	response, err := o.client.Chat.Completions.New(ctx, *params, objectCallUARequestOptions(call)...)
+	response, err := o.client.Chat.Completions.New(ctx, *params, append(objectCallUARequestOptions(call), objectCallHeadersRequestOptions(call)...)...)
 	if err != nil {
 		return nil, toProviderErr(err)
 	}
@@ -848,7 +848,7 @@ func (o languageModel) streamObjectWithJSONMode(ctx context.Context, call fantas
 		IncludeUsage: openai.Bool(true),
 	}
 
-	stream := o.client.Chat.Completions.NewStreaming(ctx, *params, objectCallUARequestOptions(call)...)
+	stream := o.client.Chat.Completions.NewStreaming(ctx, *params, append(objectCallUARequestOptions(call), objectCallHeadersRequestOptions(call)...)...)
 
 	return func(yield func(fantasy.ObjectStreamPart) bool) {
 		if len(warnings) > 0 {

--- a/providers/openai/responses_language_model.go
+++ b/providers/openai/responses_language_model.go
@@ -776,7 +776,7 @@ func (o responsesLanguageModel) Generate(ctx context.Context, call fantasy.Call)
 		return nil, err
 	}
 
-	response, err := o.client.Responses.New(ctx, *params, callUARequestOptions(call)...)
+	response, err := o.client.Responses.New(ctx, *params, append(callUARequestOptions(call), callHeadersRequestOptions(call)...)...)
 	if err != nil {
 		return nil, toProviderErr(err)
 	}
@@ -931,7 +931,7 @@ func (o responsesLanguageModel) Stream(ctx context.Context, call fantasy.Call) (
 		return nil, err
 	}
 
-	stream := o.client.Responses.NewStreaming(ctx, *params, callUARequestOptions(call)...)
+	stream := o.client.Responses.NewStreaming(ctx, *params, append(callUARequestOptions(call), callHeadersRequestOptions(call)...)...)
 
 	finishReason := fantasy.FinishReasonUnknown
 	var usage fantasy.Usage
@@ -1418,7 +1418,7 @@ func (o responsesLanguageModel) generateObjectWithJSONMode(ctx context.Context, 
 	}
 
 	// Make request
-	response, err := o.client.Responses.New(ctx, *params, objectCallUARequestOptions(call)...)
+	response, err := o.client.Responses.New(ctx, *params, append(objectCallUARequestOptions(call), objectCallHeadersRequestOptions(call)...)...)
 	if err != nil {
 		return nil, toProviderErr(err)
 	}
@@ -1521,7 +1521,7 @@ func (o responsesLanguageModel) streamObjectWithJSONMode(ctx context.Context, ca
 		Format: responses.ResponseFormatTextConfigParamOfJSONSchema(schemaName, jsonSchemaMap),
 	}
 
-	stream := o.client.Responses.NewStreaming(ctx, *params, objectCallUARequestOptions(call)...)
+	stream := o.client.Responses.NewStreaming(ctx, *params, append(objectCallUARequestOptions(call), objectCallHeadersRequestOptions(call)...)...)
 
 	return func(yield func(fantasy.ObjectStreamPart) bool) {
 		if len(warnings) > 0 {


### PR DESCRIPTION
This allows custom headers to be set on the per-call level. Prior to this they could only be set on the provider level. An example use case here is to be able to send session affinity headers to maximize caching.

Headers set in this manner will override provider level settings on a per-header basis.