### PR TITLE
feat(stream): catch transport errors and retry

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/x/exp/slice"
+	"golang.org/x/net/http2"
 )
 
 // Error is a custom error type for the fantasy package.
@@ -53,14 +54,24 @@ func (m *ProviderError) Error() string {
 	return fmt.Sprintf("%s: %s", m.Title, m.Message)
 }
 
+// Unwrap returns the underlying cause so errors.Is and errors.As can
+// inspect the wrapped error (e.g. an HTTP/2 transport error).
+func (m *ProviderError) Unwrap() error {
+	return m.Cause
+}
+
 // IsRetryable reports whether the error should be retried.
 // It returns true if the underlying cause is io.ErrUnexpectedEOF, if the
-// "x-should-retry" response header evaluates to true, or if the HTTP status
-// code indicates a retryable condition (408, 409, 429, or any 5xx).
+// "x-should-retry" response header evaluates to true, if the HTTP status
+// code indicates a retryable condition (408, 409, 429, or any 5xx), or
+// if the cause is a transient HTTP/2 transport error.
 func (m *ProviderError) IsRetryable() bool {
 	// We're mostly mimicking OpenAI's Go SDK here:
 	// https://github.com/openai/openai-go/blob/b9d280a37149430982e9dfeed16c41d27d45cfc5/internal/requestconfig/requestconfig.go#L244
 	if errors.Is(m.Cause, io.ErrUnexpectedEOF) {
+		return true
+	}
+	if IsTransportError(m.Cause) {
 		return true
 	}
 	if m.shouldRetryHeader() {
@@ -101,6 +112,122 @@ func NewIncompleteStreamError() *ProviderError {
 		Message: io.ErrUnexpectedEOF.Error(),
 		Cause:   io.ErrUnexpectedEOF,
 	}
+}
+
+// http2TransportErrorFragments are message fragments that identify a
+// transient HTTP/2 transport failure. Go's standard library bundles its
+// own copy of the http2 package whose error types are unexported, so they
+// cannot be matched with errors.As. We fall back to matching these stable
+// fragments, which both the stdlib and x/net/http2 use. The list is kept
+// tight to avoid misclassifying application-level errors as transport
+// failures.
+var http2TransportErrorFragments = []string{
+	"stream error:",     // RST_STREAM: INTERNAL_ERROR, REFUSED_STREAM, CANCEL, etc.
+	"connection error:", // connection-level protocol error
+}
+
+// IsTransportError reports whether err or any error in its chain is a
+// transient transport-level failure that is safe to retry on a fresh
+// connection. In practice these are HTTP/2 stream resets, connection
+// errors, and GOAWAY frames, which originate from the transport rather
+// than the application.
+//
+// x/net/http2 error types are matched by type; Go's stdlib-bundled http2
+// uses unexported types, so those are matched by their message fragments.
+func IsTransportError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var (
+		streamErr http2.StreamError
+		connErr   http2.ConnectionError
+		goAwayErr http2.GoAwayError
+	)
+	if errors.As(err, &streamErr) ||
+		errors.As(err, &connErr) ||
+		errors.As(err, &goAwayErr) {
+		return true
+	}
+	// Wrapped errors embed the inner message, so scanning the top-level
+	// string covers the whole chain.
+	msg := err.Error()
+	for _, fragment := range http2TransportErrorFragments {
+		if strings.Contains(msg, fragment) {
+			return true
+		}
+	}
+	return false
+}
+
+// NewTransportError wraps a transient transport error into a retryable
+// ProviderError with a human-friendly title and message.
+func NewTransportError(err error) *ProviderError {
+	return &ProviderError{
+		Title:   "stream transport error",
+		Message: extractHTTP2ErrorMessage(err),
+		Cause:   err,
+	}
+}
+
+// WrapTransportError wraps a transient transport failure in a retryable
+// ProviderError so callers get a clean message and .IsRetryable() reports
+// true. It recognizes an unexpected mid-stream EOF and HTTP/2 stream,
+// connection, and GOAWAY resets. Any other error is returned unchanged.
+//
+// This is the canonical entry point for provider error handlers: they can
+// hand off whatever the transport surfaced without re-encoding which
+// failures count as transient.
+func WrapTransportError(err error) error {
+	switch {
+	case errors.Is(err, io.ErrUnexpectedEOF):
+		return &ProviderError{
+			Title:   "stream transport error",
+			Message: err.Error(),
+			Cause:   err,
+		}
+	case IsTransportError(err):
+		return NewTransportError(err)
+	default:
+		return err
+	}
+}
+
+// extractHTTP2ErrorMessage locates the HTTP/2 error fragment within a
+// possibly-wrapped error message and returns a concise, cleaned form for
+// display. It falls back to the full message when no fragment is found.
+//
+//	"stream error: stream ID 27; INTERNAL_ERROR; received from peer" → "INTERNAL_ERROR (received from peer)"
+//	"stream error: stream ID 5; REFUSED_STREAM"                      → "REFUSED_STREAM"
+//	"http2: connection error: INTERNAL_ERROR"                        → "INTERNAL_ERROR"
+func extractHTTP2ErrorMessage(err error) string {
+	msg := err.Error()
+	for _, fragment := range http2TransportErrorFragments {
+		if i := strings.Index(msg, fragment); i != -1 {
+			return cleanHTTP2ErrorMessage(msg[i:])
+		}
+	}
+	return msg
+}
+
+// cleanHTTP2ErrorMessage trims the verbose framing from an HTTP/2 error
+// string that begins at a known fragment. "stream error: stream ID N; CODE"
+// collapses to "CODE" (with any trailing cause in parentheses), and
+// "connection error: CODE" collapses to "CODE".
+func cleanHTTP2ErrorMessage(msg string) string {
+	// "stream error: stream ID N; CODE[; cause]".
+	if idx := strings.Index(msg, "; "); idx != -1 {
+		rest := msg[idx+2:]
+		code, cause, hasCause := strings.Cut(rest, "; ")
+		if hasCause {
+			return fmt.Sprintf("%s (%s)", code, cause)
+		}
+		return code
+	}
+	// "connection error: CODE".
+	if _, code, ok := strings.Cut(msg, ": "); ok {
+		return code
+	}
+	return msg
 }
 
 // RetryError represents an error that occurred during retry operations.

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,113 @@
+package fantasy
+
+import (
+	"fmt"
+	"testing"
+
+	"golang.org/x/net/http2"
+)
+
+func TestIsTransportError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil error", nil, false},
+		{"stream error with peer", newTestError("stream error: stream ID 27; INTERNAL_ERROR; received from peer"), true},
+		{"stream error without peer", newTestError("stream error: stream ID 5; REFUSED_STREAM"), true},
+		{"connection error", newTestError("connection error: INTERNAL_ERROR"), true},
+		{"http2-prefixed connection error", newTestError("http2: connection error: PROTOCOL_ERROR: bad frame"), true},
+		{"generic error", newTestError("something went wrong"), false},
+		{"EOF", newTestError("EOF"), false},
+		{"empty error", newTestError(""), false},
+		{"wrapped stream error", fmt.Errorf("reading body: %w", newTestError("stream error: stream ID 3; INTERNAL_ERROR")), true},
+		{"x/net StreamError", http2.StreamError{StreamID: 1, Code: http2.ErrCodeInternal}, true},
+		{"x/net ConnectionError", http2.ConnectionError(http2.ErrCodeInternal), true},
+		{"x/net GoAwayError", http2.GoAwayError{LastStreamID: 1, ErrCode: http2.ErrCodeInternal}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := IsTransportError(tt.err); got != tt.want {
+				t.Errorf("IsTransportError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCleanHTTP2ErrorMessage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{
+			"stream error: stream ID 27; INTERNAL_ERROR; received from peer",
+			"INTERNAL_ERROR (received from peer)",
+		},
+		{
+			"stream error: stream ID 5; REFUSED_STREAM",
+			"REFUSED_STREAM",
+		},
+		{
+			"connection error: INTERNAL_ERROR",
+			"INTERNAL_ERROR",
+		},
+		{
+			"some other error",
+			"some other error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
+			if got := cleanHTTP2ErrorMessage(tt.input); got != tt.want {
+				t.Errorf("cleanHTTP2ErrorMessage(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewTransportError(t *testing.T) {
+	t.Parallel()
+
+	rawErr := newTestError("stream error: stream ID 27; INTERNAL_ERROR; received from peer")
+	err := NewTransportError(rawErr)
+
+	if err.Title != "stream transport error" {
+		t.Errorf("Title = %q, want %q", err.Title, "stream transport error")
+	}
+	if err.Message != "INTERNAL_ERROR (received from peer)" {
+		t.Errorf("Message = %q, want %q", err.Message, "INTERNAL_ERROR (received from peer)")
+	}
+	if !err.IsRetryable() {
+		t.Error("expected HTTP/2 transport error to be retryable")
+	}
+}
+
+func TestNewTransportErrorWrapped(t *testing.T) {
+	t.Parallel()
+
+	rawErr := fmt.Errorf("reading response body: %w",
+		newTestError("stream error: stream ID 12; REFUSED_STREAM"))
+	err := NewTransportError(rawErr)
+
+	if err.Message != "REFUSED_STREAM" {
+		t.Errorf("Message = %q, want %q", err.Message, "REFUSED_STREAM")
+	}
+	if !err.IsRetryable() {
+		t.Error("expected wrapped HTTP/2 transport error to be retryable")
+	}
+}
+
+type testError struct{ msg string }
+
+func (e *testError) Error() string { return e.msg }
+
+func newTestError(msg string) error { return &testError{msg: msg} }

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/kaptinlin/jsonschema v0.9.3
 	github.com/openai/openai-go/v3 v3.43.0
 	github.com/stretchr/testify v1.11.1
+	golang.org/x/net v0.57.0
 	golang.org/x/oauth2 v0.36.0
 	google.golang.org/genai v1.63.0
 )
@@ -111,7 +112,6 @@ require (
 	go.yaml.in/yaml/v4 v4.0.0-rc.3 // indirect
 	golang.org/x/crypto v0.54.0 // indirect
 	golang.org/x/image v0.44.0 // indirect
-	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.40.0 // indirect

--- a/providers/anthropic/error.go
+++ b/providers/anthropic/error.go
@@ -3,7 +3,6 @@ package anthropic
 import (
 	"cmp"
 	"errors"
-	"io"
 	"net/http"
 	"regexp"
 	"strconv"
@@ -33,15 +32,8 @@ func toProviderErr(err error) error {
 
 		return providerErr
 	}
-	// Wrap in a `ProviderError` so `.IsRetriable()` works.
-	if errors.Is(err, io.ErrUnexpectedEOF) {
-		return &fantasy.ProviderError{
-			Title:   "stream transport error",
-			Message: err.Error(),
-			Cause:   err,
-		}
-	}
-	return err
+	// Wrap transient transport failures so `.IsRetryable()` works.
+	return fantasy.WrapTransportError(err)
 }
 
 func parseContextTooLargeError(message string, providerErr *fantasy.ProviderError) {

--- a/providers/google/error.go
+++ b/providers/google/error.go
@@ -3,7 +3,6 @@ package google
 import (
 	"cmp"
 	"errors"
-	"io"
 	"regexp"
 	"strconv"
 
@@ -16,15 +15,8 @@ var googleContextPattern = regexp.MustCompile(`input token count.*?(\d+).*?excee
 func toProviderErr(err error) error {
 	var apiErr genai.APIError
 	if !errors.As(err, &apiErr) {
-		// Wrap in a `ProviderError` so `.IsRetriable()` works.
-		if errors.Is(err, io.ErrUnexpectedEOF) {
-			return &fantasy.ProviderError{
-				Title:   "stream transport error",
-				Message: err.Error(),
-				Cause:   err,
-			}
-		}
-		return err
+		// Wrap transient transport failures so `.IsRetryable()` works.
+		return fantasy.WrapTransportError(err)
 	}
 
 	providerErr := &fantasy.ProviderError{

--- a/providers/openai/error.go
+++ b/providers/openai/error.go
@@ -38,15 +38,8 @@ func toProviderErr(err error) error {
 
 		return providerErr
 	}
-	// Wrap in a `ProviderError` so `.IsRetriable()` works.
-	if errors.Is(err, io.ErrUnexpectedEOF) {
-		return &fantasy.ProviderError{
-			Title:   "stream transport error",
-			Message: err.Error(),
-			Cause:   err,
-		}
-	}
-	return err
+	// Wrap transient transport failures so `.IsRetryable()` works.
+	return fantasy.WrapTransportError(err)
 }
 
 func parseContextTooLargeError(message string, providerErr *fantasy.ProviderError) {

--- a/providers/openai/stream_reset_test.go
+++ b/providers/openai/stream_reset_test.go
@@ -1,0 +1,72 @@
+package openai
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"charm.land/fantasy"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStreamHTTP2StreamReset proves the full chain end to end: a real
+// HTTP/2 RST_STREAM sent mid-response surfaces as a retryable
+// ProviderError so the agent's retry middleware re-runs the step.
+//
+// The server streams a partial SSE chunk, flushes, then aborts the
+// handler. On an HTTP/2 connection this makes the transport send an
+// RST_STREAM(INTERNAL_ERROR) to the client, which is exactly the
+// "stream error: stream ID N; INTERNAL_ERROR; received from peer"
+// failure observed in production.
+func TestStreamHTTP2StreamReset(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		// Stream a valid partial chunk so the client is mid-stream.
+		fmt.Fprint(w, "data: {\"id\":\"1\",\"object\":\"chat.completion.chunk\","+
+			"\"choices\":[{\"index\":0,\"delta\":{\"content\":\"partial\"}}]}\n\n")
+		w.(http.Flusher).Flush()
+		// Abort mid-stream: on HTTP/2 this emits RST_STREAM to the peer.
+		panic(http.ErrAbortHandler)
+	}))
+	srv.EnableHTTP2 = true
+	srv.StartTLS()
+	defer srv.Close()
+
+	provider, err := New(
+		WithAPIKey("test-api-key"),
+		WithBaseURL(srv.URL),
+		// srv.Client() trusts the test cert and negotiates HTTP/2.
+		WithHTTPClient(srv.Client()),
+	)
+	require.NoError(t, err)
+
+	model, err := provider.LanguageModel(t.Context(), "gpt-3.5-turbo")
+	require.NoError(t, err)
+
+	stream, err := model.Stream(context.Background(), fantasy.Call{Prompt: testPrompt})
+	require.NoError(t, err)
+
+	var streamErr error
+	for part := range stream {
+		if part.Type == fantasy.StreamPartTypeError {
+			streamErr = part.Error
+		}
+	}
+
+	require.Error(t, streamErr, "expected a stream error from the RST_STREAM")
+
+	// The error must be classified as a transient HTTP/2 transport error.
+	require.True(t, fantasy.IsTransportError(streamErr),
+		"error should be detected as HTTP/2 transport error, got: %v", streamErr)
+
+	// It must be wrapped as a retryable ProviderError so the retry
+	// middleware engages.
+	var provErr *fantasy.ProviderError
+	require.ErrorAs(t, streamErr, &provErr)
+	require.True(t, provErr.IsRetryable(), "provider error should be retryable")
+}

--- a/retry.go
+++ b/retry.go
@@ -96,7 +96,17 @@ type RetryOptions struct {
 	OnAuthRefresh OnAuthRefreshFunc
 }
 
-// OnRetryCallback defines a function that is called when a retry occurs.
+// OnRetryCallback is called before each retry attempt, after the retry
+// delay is chosen but before it elapses. err is the failure that triggered
+// the retry (nil if the failure was not a *ProviderError) and delay is how
+// long the middleware will wait before the next attempt.
+//
+// A retry re-runs the entire step from scratch: the stream is recreated and
+// the stream callbacks (OnTextStart, OnTextDelta, OnReasoningStart,
+// OnReasoningDelta, OnToolInputStart, etc.) fire again from the beginning of
+// the new response. Consumers that accumulate streamed content must reset
+// that accumulated state here, otherwise the retried response is appended to
+// the partial content from the failed attempt.
 type OnRetryCallback = func(err *ProviderError, delay time.Duration)
 
 // DefaultRetryOptions returns the default retry options.
@@ -166,9 +176,10 @@ func isAuthError(err *ProviderError) bool {
 }
 
 // isRetryableError reports whether the error should be retried.
-// It checks for retryable ProviderError and also retries network-level
-// connection errors (DNS failures, TCP timeouts, connection refused, etc.)
-// that never produce an HTTP response and therefore aren't wrapped in ProviderError.
+// It checks for retryable ProviderError, network-level connection errors
+// (DNS failures, TCP timeouts, connection refused), and HTTP/2 stream-
+// level transport errors. The latter two categories may not be wrapped
+// in ProviderError when they occur outside the provider's error handler.
 func isRetryableError(err error) bool {
 	var providerErr *ProviderError
 	if errors.As(err, &providerErr) {
@@ -178,7 +189,10 @@ func isRetryableError(err error) bool {
 		return false
 	}
 	var netErr net.Error
-	return errors.As(err, &netErr)
+	if errors.As(err, &netErr) {
+		return true
+	}
+	return IsTransportError(err)
 }
 
 // isAbortError checks if the error is a context cancellation error.

--- a/retry_test.go
+++ b/retry_test.go
@@ -64,6 +64,35 @@ func TestIsRetryableError(t *testing.T) {
 			t.Error("expected generic error to not be retryable")
 		}
 	})
+
+	t.Run("HTTP/2 stream error is retryable", func(t *testing.T) {
+		t.Parallel()
+		err := errors.New("stream error: stream ID 27; INTERNAL_ERROR; received from peer")
+		if !isRetryableError(err) {
+			t.Error("expected HTTP/2 stream error to be retryable")
+		}
+	})
+
+	t.Run("HTTP/2 connection error is retryable", func(t *testing.T) {
+		t.Parallel()
+		err := errors.New("connection error: INTERNAL_ERROR")
+		if !isRetryableError(err) {
+			t.Error("expected HTTP/2 connection error to be retryable")
+		}
+	})
+
+	t.Run("ProviderError wrapping HTTP/2 stream error is retryable", func(t *testing.T) {
+		t.Parallel()
+		rawErr := errors.New("stream error: stream ID 5; REFUSED_STREAM")
+		err := &ProviderError{
+			Title:   "stream transport error",
+			Message: "REFUSED_STREAM",
+			Cause:   rawErr,
+		}
+		if !isRetryableError(err) {
+			t.Error("expected ProviderError wrapping HTTP/2 stream error to be retryable")
+		}
+	})
 }
 
 func TestRetryWithExponentialBackoff_ConnectionErrors(t *testing.T) {
@@ -139,6 +168,35 @@ func TestRetryWithExponentialBackoff_ConnectionErrors(t *testing.T) {
 		var retryErr *RetryError
 		if !errors.As(err, &retryErr) {
 			t.Fatalf("expected RetryError, got %T: %v", err, err)
+		}
+	})
+
+	t.Run("retries on HTTP/2 stream error", func(t *testing.T) {
+		t.Parallel()
+		attempts := 0
+		opts := RetryOptions{
+			MaxRetries:     2,
+			InitialDelayIn: 1 * time.Millisecond,
+			BackoffFactor:  2.0,
+		}
+
+		retryFn := RetryWithExponentialBackoffRespectingRetryHeaders[int](opts)
+
+		result, err := retryFn(context.Background(), func() (int, error) {
+			attempts++
+			if attempts < 3 {
+				return 0, errors.New("stream error: stream ID 27; INTERNAL_ERROR; received from peer")
+			}
+			return 42, nil
+		})
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if result != 42 {
+			t.Fatalf("expected result 42, got %d", result)
+		}
+		if attempts != 3 {
+			t.Fatalf("expected 3 attempts, got %d", attempts)
 		}
 	})
 }


### PR DESCRIPTION
When a provider's HTTP/2 connection resets a stream mid-response, the transport
surfaces an error like:

```
stream error: stream ID 27; INTERNAL_ERROR; received from peer
```

These are transient transport failures (the server dropped the stream etc) but they were treated as non retriable. A single flaky stream would end
the turn with an ugly, low-level error message even though retrying on a fresh
connection almost always succeeds. The existing retry path already covered
io.ErrUnexpectedEOF  and incomplete-stream endings, but stream resets fell
through because they aren't an `EOF`, aren't a `net.Error`, and carry no HTTP
status code.

upstream crush pr https://github.com/charmbracelet/crush/pull/3305