### PR TITLE
chore: switch back to upstream openai sdk

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.27
 	github.com/aws/smithy-go v1.27.3
 	github.com/charmbracelet/anthropic-sdk-go v0.0.0-20260223140439-63879b0b8dab
-	github.com/charmbracelet/openai-go v0.0.0-20260617131321-5e4b9c18c4be
 	github.com/charmbracelet/x/exp/slice v0.0.0-20250904123553-b4e2667e5ad5
 	github.com/charmbracelet/x/exp/strings v0.1.0
 	github.com/charmbracelet/x/json v0.2.0
@@ -18,6 +17,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/joho/godotenv v1.5.1
 	github.com/kaptinlin/jsonschema v0.9.3
+	github.com/openai/openai-go/v3 v3.43.0
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/oauth2 v0.36.0
 	google.golang.org/genai v1.62.0

--- a/go.sum
+++ b/go.sum
@@ -88,8 +88,6 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/charmbracelet/anthropic-sdk-go v0.0.0-20260223140439-63879b0b8dab h1:J7XQLgl9sefgTnTGrmX3xqvp5o6MCiBzEjGv5igAlc4=
 github.com/charmbracelet/anthropic-sdk-go v0.0.0-20260223140439-63879b0b8dab/go.mod h1:hqlYqR7uPKOKfnNeicUbZp0Ps0GeYFlKYtwh5HGDCx8=
-github.com/charmbracelet/openai-go v0.0.0-20260617131321-5e4b9c18c4be h1:pg+OWlIkk9HOe/8P5J95aKe2wGDzFUiiyFOUpwR30B4=
-github.com/charmbracelet/openai-go v0.0.0-20260617131321-5e4b9c18c4be/go.mod h1:1DahUaExbUZx/jD+FNT2PKP4L9rLE5+ZBRuI8mZjd/E=
 github.com/charmbracelet/x/exp/slice v0.0.0-20250904123553-b4e2667e5ad5 h1:DTSZxdV9qQagD4iGcAt9RgaRBZtJl01bfKgdLzUzUPI=
 github.com/charmbracelet/x/exp/slice v0.0.0-20250904123553-b4e2667e5ad5/go.mod h1:vI5nDVMWi6veaYH+0Fmvpbe/+cv/iJfMntdh+N0+Tms=
 github.com/charmbracelet/x/exp/strings v0.1.0 h1:i69S2XI7uG1u4NLGeJPSYU++Nmjvpo9nwd6aoEm7gkA=
@@ -177,6 +175,8 @@ github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/openai/openai-go/v3 v3.43.0 h1:C+MFVUMU3TJNgES+Ikt7HF8xcX7J0wynKeR9ST22hZM=
+github.com/openai/openai-go/v3 v3.43.0/go.mod h1:cdufnVK14cWcT9qA1rRtrXx4FTRsgbDPW7Ia7SS5cZo=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 h1:GFCKgmp0tecUJ0sJuv4pzYCqS9+RGSn52M3FUwPs+uo=

--- a/providers/azure/azure.go
+++ b/providers/azure/azure.go
@@ -8,8 +8,8 @@ import (
 
 	"charm.land/fantasy"
 	"charm.land/fantasy/providers/openai"
-	"github.com/charmbracelet/openai-go/azure"
-	"github.com/charmbracelet/openai-go/option"
+	"github.com/openai/openai-go/v3/azure"
+	"github.com/openai/openai-go/v3/option"
 )
 
 type options struct {

--- a/providers/openai/call_useragent.go
+++ b/providers/openai/call_useragent.go
@@ -3,7 +3,7 @@ package openai
 import (
 	"charm.land/fantasy"
 	"charm.land/fantasy/providers/internal/httpheaders"
-	"github.com/charmbracelet/openai-go/option"
+	"github.com/openai/openai-go/v3/option"
 )
 
 // callUARequestOptions returns per-request options that override the

--- a/providers/openai/error.go
+++ b/providers/openai/error.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"charm.land/fantasy"
-	"github.com/charmbracelet/openai-go"
+	"github.com/openai/openai-go/v3"
 )
 
 var (

--- a/providers/openai/language_model.go
+++ b/providers/openai/language_model.go
@@ -14,10 +14,10 @@ import (
 	"charm.land/fantasy"
 	"charm.land/fantasy/object"
 	"charm.land/fantasy/schema"
-	"github.com/charmbracelet/openai-go"
-	"github.com/charmbracelet/openai-go/packages/param"
-	"github.com/charmbracelet/openai-go/shared"
 	"github.com/google/uuid"
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/packages/param"
+	"github.com/openai/openai-go/v3/shared"
 )
 
 type languageModel struct {

--- a/providers/openai/language_model_hooks.go
+++ b/providers/openai/language_model_hooks.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 
 	"charm.land/fantasy"
-	"github.com/charmbracelet/openai-go"
-	"github.com/charmbracelet/openai-go/packages/param"
-	"github.com/charmbracelet/openai-go/shared"
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/packages/param"
+	"github.com/openai/openai-go/v3/shared"
 )
 
 // LanguageModelPrepareCallFunc is a function that prepares the call for the language model.

--- a/providers/openai/openai.go
+++ b/providers/openai/openai.go
@@ -8,8 +8,8 @@ import (
 
 	"charm.land/fantasy"
 	"charm.land/fantasy/providers/internal/httpheaders"
-	"github.com/charmbracelet/openai-go"
-	"github.com/charmbracelet/openai-go/option"
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
 )
 
 const (

--- a/providers/openai/openai_test.go
+++ b/providers/openai/openai_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 
 	"charm.land/fantasy"
-	"github.com/charmbracelet/openai-go/packages/param"
+	"github.com/openai/openai-go/v3/packages/param"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/providers/openai/provider_options.go
+++ b/providers/openai/provider_options.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 
 	"charm.land/fantasy"
-	"github.com/charmbracelet/openai-go"
-	"github.com/charmbracelet/openai-go/packages/respjson"
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/packages/respjson"
 )
 
 // ReasoningEffort represents the reasoning effort level for OpenAI models.

--- a/providers/openai/responses_language_model.go
+++ b/providers/openai/responses_language_model.go
@@ -12,11 +12,11 @@ import (
 	"charm.land/fantasy"
 	"charm.land/fantasy/object"
 	"charm.land/fantasy/schema"
-	"github.com/charmbracelet/openai-go"
-	"github.com/charmbracelet/openai-go/packages/param"
-	"github.com/charmbracelet/openai-go/responses"
-	"github.com/charmbracelet/openai-go/shared"
 	"github.com/google/uuid"
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/packages/param"
+	"github.com/openai/openai-go/v3/responses"
+	"github.com/openai/openai-go/v3/shared"
 )
 
 const topLogprobsMax = 20

--- a/providers/openaicompat/language_model_hooks.go
+++ b/providers/openaicompat/language_model_hooks.go
@@ -8,9 +8,9 @@ import (
 
 	"charm.land/fantasy"
 	"charm.land/fantasy/providers/openai"
-	openaisdk "github.com/charmbracelet/openai-go"
-	"github.com/charmbracelet/openai-go/packages/param"
-	"github.com/charmbracelet/openai-go/shared"
+	openaisdk "github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/packages/param"
+	"github.com/openai/openai-go/v3/shared"
 )
 
 const reasoningStartedCtx = "reasoning_started"

--- a/providers/openaicompat/openaicompat.go
+++ b/providers/openaicompat/openaicompat.go
@@ -4,7 +4,7 @@ package openaicompat
 import (
 	"charm.land/fantasy"
 	"charm.land/fantasy/providers/openai"
-	"github.com/charmbracelet/openai-go/option"
+	"github.com/openai/openai-go/v3/option"
 )
 
 type options struct {

--- a/providers/openrouter/language_model_hooks.go
+++ b/providers/openrouter/language_model_hooks.go
@@ -11,9 +11,9 @@ import (
 	"charm.land/fantasy/providers/anthropic"
 	"charm.land/fantasy/providers/google"
 	"charm.land/fantasy/providers/openai"
-	openaisdk "github.com/charmbracelet/openai-go"
-	"github.com/charmbracelet/openai-go/packages/param"
 	xstrings "github.com/charmbracelet/x/exp/strings"
+	openaisdk "github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/packages/param"
 )
 
 const reasoningStartedCtx = "reasoning_started"

--- a/providers/openrouter/openrouter.go
+++ b/providers/openrouter/openrouter.go
@@ -6,7 +6,7 @@ import (
 
 	"charm.land/fantasy"
 	"charm.land/fantasy/providers/openai"
-	"github.com/charmbracelet/openai-go/option"
+	"github.com/openai/openai-go/v3/option"
 )
 
 type options struct {

--- a/providers/vercel/language_model_hooks.go
+++ b/providers/vercel/language_model_hooks.go
@@ -11,8 +11,8 @@ import (
 	"charm.land/fantasy/providers/anthropic"
 	"charm.land/fantasy/providers/google"
 	openaipkg "charm.land/fantasy/providers/openai"
-	openaisdk "github.com/charmbracelet/openai-go"
-	"github.com/charmbracelet/openai-go/packages/param"
+	openaisdk "github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/packages/param"
 )
 
 const reasoningStartedCtx = "reasoning_started"

--- a/providers/vercel/vercel.go
+++ b/providers/vercel/vercel.go
@@ -4,7 +4,7 @@ package vercel
 import (
 	"charm.land/fantasy"
 	"charm.land/fantasy/providers/openai"
-	"github.com/charmbracelet/openai-go/option"
+	"github.com/openai/openai-go/v3/option"
 )
 
 type options struct {


### PR DESCRIPTION
* Crush PR: https://github.com/charmbracelet/crush/pull/3308
* Ref: https://github.com/openai/openai-go/issues/556
* Ref: https://github.com/openai/openai-go/pull/621

We were using our own fork with a fix for SSE comment breaking the SDK. (Only specific providers send SSE comments and were failing with it, like OpenRouter).

This was fixed and now we can use upstream again.