### PR TITLE
fix: increase default retry backoff to 5s and 3 max retries

### DIFF
--- a/retry.go
+++ b/retry.go
@@ -102,8 +102,8 @@ type OnRetryCallback = func(err *ProviderError, delay time.Duration)
 // DefaultRetryOptions returns the default retry options.
 func DefaultRetryOptions() RetryOptions {
 	return RetryOptions{
-		MaxRetries:     2,
-		InitialDelayIn: 2000 * time.Millisecond,
+		MaxRetries:     3,
+		InitialDelayIn: 5000 * time.Millisecond,
 		BackoffFactor:  2.0,
 	}
 }


### PR DESCRIPTION
Previous defaults (2 retries, 2s initial delay) were too aggressive for transient provider errors like rate limits and service unavailable. New sequence is 5s → 10s → 20s (35s worst case).

Assisted-by: Crush:glm-5.2