### PR TITLE
fix(openai): classify in-band SSE stream errors for retry

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -51,6 +51,12 @@ type ProviderError struct {
 	// interactive login). It covers auth failures that do not carry an HTTP
 	// 401 status, so a caller-supplied OnAuthRefresh hook still engages.
 	AuthError bool
+
+	// TransientError marks a temporary server-side failure worth retrying
+	// despite carrying no retryable HTTP status code. Mid-stream SSE error
+	// events ride inside an already-successful 200 response, so the status
+	// code alone cannot signal that a retry may succeed.
+	TransientError bool
 }
 
 func (m *ProviderError) Error() string {
@@ -67,11 +73,15 @@ func (m *ProviderError) Unwrap() error {
 }
 
 // IsRetryable reports whether the error should be retried.
-// It returns true if the underlying cause is io.ErrUnexpectedEOF, if the
-// "x-should-retry" response header evaluates to true, if the HTTP status
-// code indicates a retryable condition (408, 409, 429, or any 5xx), or
-// if the cause is a transient HTTP/2 transport error.
+// It returns true if the error is flagged as transient, if the underlying
+// cause is io.ErrUnexpectedEOF, if the "x-should-retry" response header
+// evaluates to true, if the HTTP status code indicates a retryable
+// condition (408, 409, 429, or any 5xx), or if the cause is a transient
+// HTTP/2 transport error.
 func (m *ProviderError) IsRetryable() bool {
+	if m.TransientError {
+		return true
+	}
 	// We're mostly mimicking OpenAI's Go SDK here:
 	// https://github.com/openai/openai-go/blob/b9d280a37149430982e9dfeed16c41d27d45cfc5/internal/requestconfig/requestconfig.go#L244
 	if errors.Is(m.Cause, io.ErrUnexpectedEOF) {
@@ -173,6 +183,22 @@ func NewTransportError(err error) *ProviderError {
 		Message: extractHTTP2ErrorMessage(err),
 		Cause:   err,
 	}
+}
+
+// TransientStreamErrorTypes are provider error "type" (or "code") values
+// that name a temporary server-side condition worth retrying. Mid-stream
+// SSE error events ride inside an already-successful 200 response, so the
+// HTTP status code cannot signal retryability; providers classify the
+// payload against this set and set ProviderError.TransientError.
+//
+// This is the canonical list. Providers parse their SDK-specific error
+// shapes but defer the transient/permanent policy decision here.
+var TransientStreamErrorTypes = map[string]bool{
+	"server_error":     true,
+	"internal_error":   true,
+	"overloaded_error": true,
+	"api_error":        true,
+	"rate_limit_error": true,
 }
 
 // WrapTransportError wraps a transient transport failure in a retryable

--- a/providers/anthropic/anthropic_test.go
+++ b/providers/anthropic/anthropic_test.go
@@ -921,11 +921,21 @@ func TestStream_RequiresMessageStopBeforeFinish(t *testing.T) {
 			wantRetryable: true,
 		},
 		{
-			name: "provider error event is preserved",
+			// api_error is a temporary provider-side fault, so it is worth
+			// retrying even though it arrived inside a 200 response.
+			name: "provider error event is preserved and retried",
 			chunks: []string{
 				anthropicSSEEvent("error", `{"type":"error","error":{"type":"api_error","message":"stream down"}}`),
 			},
+			wantRetryable: true,
 			wantErrContain: "stream down",
+		},
+		{
+			name: "permanent error event is not retried",
+			chunks: []string{
+				anthropicSSEEvent("error", `{"type":"error","error":{"type":"invalid_request_error","message":"bad request"}}`),
+			},
+			wantErrContain: "bad request",
 		},
 	}
 
@@ -978,7 +988,6 @@ func TestStream_RequiresMessageStopBeforeFinish(t *testing.T) {
 			if tt.wantRetryable {
 				require.ErrorAs(t, errorParts[0].Error, &providerErr)
 				require.True(t, providerErr.IsRetryable())
-				require.ErrorIs(t, providerErr.Cause, io.ErrUnexpectedEOF)
 			} else {
 				require.NotErrorIs(t, errorParts[0].Error, io.ErrUnexpectedEOF)
 				if errors.As(errorParts[0].Error, &providerErr) {

--- a/providers/anthropic/error.go
+++ b/providers/anthropic/error.go
@@ -2,6 +2,7 @@ package anthropic
 
 import (
 	"cmp"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"regexp"
@@ -48,8 +49,70 @@ func toProviderErr(err error) error {
 			AuthError: true,
 		}
 	}
-	// Wrap transient transport failures so `.IsRetryable()` works.
+	// Wrap transient failures so `.IsRetryable()` works: mid-stream error
+	// events first, then transport-level failures.
+	if wrapped := wrapStreamError(err); wrapped != nil {
+		return wrapped
+	}
 	return fantasy.WrapTransportError(err)
+}
+
+// streamErrorPrefix is the message prefix the Anthropic SDK uses for a
+// mid-stream `error` event. The SDK reports it via fmt.Errorf with no
+// exported type, so we match the prefix and parse the payload ourselves.
+const streamErrorPrefix = "received error while streaming:"
+
+// streamErrorEnvelope is the payload of an SSE `error` event. Anthropic
+// nests the useful detail under "error"; the outer "type" is always the
+// literal "error" and carries no classification value.
+type streamErrorEnvelope struct {
+	Error *struct {
+		Type    string `json:"type"`
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+// wrapStreamError classifies a mid-stream SSE error event as a
+// ProviderError, marking it transient when the payload names a temporary
+// server-side condition. Returns nil if err is not a stream error event.
+func wrapStreamError(err error) *fantasy.ProviderError {
+	_, payload, ok := strings.Cut(err.Error(), streamErrorPrefix)
+	if !ok {
+		return nil
+	}
+	payload = strings.TrimSpace(payload)
+
+	var envelope streamErrorEnvelope
+	errType, message := "", ""
+	if json.Unmarshal([]byte(payload), &envelope) == nil && envelope.Error != nil {
+		errType = envelope.Error.Type
+		message = envelope.Error.Message
+	}
+	if errType == "" && message == "" {
+		// Nothing recognizable: let it fall through to transport handling.
+		return nil
+	}
+
+	return &fantasy.ProviderError{
+		Title:          streamErrorTitle(errType),
+		Message:        cmp.Or(message, payload),
+		Cause:          err,
+		ResponseBody:   []byte(payload),
+		TransientError: fantasy.TransientStreamErrorTypes[errType],
+	}
+}
+
+func streamErrorTitle(errType string) string {
+	switch errType {
+	case "overloaded_error":
+		return "provider overloaded"
+	case "rate_limit_error":
+		return "rate limit exceeded"
+	case "":
+		return "provider stream error"
+	default:
+		return strings.ReplaceAll(errType, "_", " ")
+	}
 }
 
 func parseContextTooLargeError(message string, providerErr *fantasy.ProviderError) {

--- a/providers/anthropic/error_test.go
+++ b/providers/anthropic/error_test.go
@@ -91,3 +91,86 @@ func TestToProviderErr_FlagsExpiredBedrockCredentials(t *testing.T) {
 		})
 	}
 }
+
+// A mid-stream SSE error event rides inside a 200 response, so only the
+// payload marks the failure as temporary.
+func TestToProviderErr_RetriesMidStreamOverload(t *testing.T) {
+	t.Parallel()
+
+	err := errors.New(`received error while streaming: {"type":"error","error":{"details":null,"type":"overloaded_error","message":"Overloaded"}}`)
+
+	var providerErr *fantasy.ProviderError
+	if !errors.As(toProviderErr(err), &providerErr) {
+		t.Fatalf("toProviderErr did not wrap %v as *fantasy.ProviderError", err)
+	}
+	if !providerErr.IsRetryable() {
+		t.Error("a mid-stream overload must be retryable so the step is re-run")
+	}
+	if !providerErr.TransientError {
+		t.Error("TransientError must be set for a transient stream error")
+	}
+	if providerErr.StatusCode != 0 {
+		t.Errorf("StatusCode = %d, want 0 (no HTTP status was returned)", providerErr.StatusCode)
+	}
+	if providerErr.Title != "provider overloaded" {
+		t.Errorf("Title = %q, want %q", providerErr.Title, "provider overloaded")
+	}
+	if providerErr.Message != "Overloaded" {
+		t.Errorf("Message = %q, want %q", providerErr.Message, "Overloaded")
+	}
+	if !errors.Is(providerErr.Cause, err) {
+		t.Error("Cause chain must include the original error")
+	}
+}
+
+func TestToProviderErr_StreamErrorTransientTypes(t *testing.T) {
+	t.Parallel()
+
+	for _, errType := range []string{"overloaded_error", "api_error", "server_error", "internal_error", "rate_limit_error"} {
+		t.Run(errType, func(t *testing.T) {
+			t.Parallel()
+
+			err := errors.New(`received error while streaming: {"type":"error","error":{"type":"` + errType + `","message":"transient"}}`)
+
+			var providerErr *fantasy.ProviderError
+			if !errors.As(toProviderErr(err), &providerErr) {
+				t.Fatalf("toProviderErr did not wrap %v as *fantasy.ProviderError", err)
+			}
+			if !providerErr.IsRetryable() {
+				t.Errorf("%s stream failure must be retryable", errType)
+			}
+		})
+	}
+}
+
+func TestToProviderErr_PermanentStreamErrorNotRetried(t *testing.T) {
+	t.Parallel()
+
+	err := errors.New(`received error while streaming: {"type":"error","error":{"type":"invalid_request_error","message":"bad tool schema"}}`)
+
+	var providerErr *fantasy.ProviderError
+	if !errors.As(toProviderErr(err), &providerErr) {
+		t.Fatalf("toProviderErr did not wrap %v as *fantasy.ProviderError", err)
+	}
+	if providerErr.IsRetryable() {
+		t.Error("a permanent stream error type must not be retryable")
+	}
+	if providerErr.Message != "bad tool schema" {
+		t.Errorf("Message = %q, want %q", providerErr.Message, "bad tool schema")
+	}
+}
+
+func TestToProviderErr_StreamErrorWrappedByOuterError(t *testing.T) {
+	t.Parallel()
+
+	inner := errors.New(`received error while streaming: {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}`)
+	err := fmt.Errorf("anthropic: %w", inner)
+
+	var providerErr *fantasy.ProviderError
+	if !errors.As(toProviderErr(err), &providerErr) {
+		t.Fatalf("toProviderErr did not wrap %v as *fantasy.ProviderError", err)
+	}
+	if !providerErr.IsRetryable() {
+		t.Error("a wrapped mid-stream overload must still be retryable")
+	}
+}

--- a/providers/openai/error.go
+++ b/providers/openai/error.go
@@ -2,6 +2,7 @@ package openai
 
 import (
 	"cmp"
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -11,6 +12,7 @@ import (
 
 	"charm.land/fantasy"
 	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/packages/ssestream"
 )
 
 var (
@@ -38,8 +40,59 @@ func toProviderErr(err error) error {
 
 		return providerErr
 	}
+
+	// The SDK only wraps errors on the initial HTTP response as *openai.Error
+	// ("Other errors are not wrapped by this SDK" -- its own doc comment). An
+	// in-band SSE error event that arrives mid-stream, after the response
+	// already returned 200 OK, surfaces as a *ssestream.StreamError instead
+	// and would otherwise never reach ProviderError.IsRetryable(), so a
+	// transient upstream failure (e.g. "type":"server_error") silently skips
+	// retry entirely instead of just being classified non-retryable.
+	var streamErr *ssestream.StreamError
+	if errors.As(err, &streamErr) {
+		return toProviderErrFromStreamError(streamErr)
+	}
+
 	// Wrap transient transport failures so `.IsRetryable()` works.
 	return fantasy.WrapTransportError(err)
+}
+
+// streamErrorEnvelope mirrors the OpenAI-standard error envelope
+// (`{"error": {"code", "message", "param", "type"}}`) that arrives as an
+// in-band SSE event on stream failure.
+type streamErrorEnvelope struct {
+	Error struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+		Param   string `json:"param"`
+		Type    string `json:"type"`
+	} `json:"error"`
+}
+
+// retryableStreamErrorTypes are the "type"/"code" values documented as
+// transient, provider-side failures -- the in-stream equivalent of an HTTP
+// 5xx on the initial request.
+var retryableStreamErrorTypes = map[string]bool{
+	"server_error": true,
+}
+
+func toProviderErrFromStreamError(streamErr *ssestream.StreamError) *fantasy.ProviderError {
+	var envelope streamErrorEnvelope
+	_ = json.Unmarshal(streamErr.Event.Data, &envelope) // best-effort; falls back to the raw message on parse failure.
+
+	providerErr := &fantasy.ProviderError{
+		Title:   "stream error",
+		Message: cmp.Or(envelope.Error.Message, streamErr.Message),
+		Cause:   streamErr,
+	}
+
+	if retryableStreamErrorTypes[envelope.Error.Type] || retryableStreamErrorTypes[envelope.Error.Code] {
+		// Synthesize a 5xx so the existing IsRetryable() status-code check
+		// covers this without needing its own special case.
+		providerErr.StatusCode = http.StatusInternalServerError
+	}
+
+	return providerErr
 }
 
 func parseContextTooLargeError(message string, providerErr *fantasy.ProviderError) {

--- a/providers/openai/error.go
+++ b/providers/openai/error.go
@@ -41,13 +41,8 @@ func toProviderErr(err error) error {
 		return providerErr
 	}
 
-	// The SDK only wraps errors on the initial HTTP response as *openai.Error
-	// ("Other errors are not wrapped by this SDK" -- its own doc comment). An
-	// in-band SSE error event that arrives mid-stream, after the response
-	// already returned 200 OK, surfaces as a *ssestream.StreamError instead
-	// and would otherwise never reach ProviderError.IsRetryable(), so a
-	// transient upstream failure (e.g. "type":"server_error") silently skips
-	// retry entirely instead of just being classified non-retryable.
+	// Mid-stream SSE error events surface as *ssestream.StreamError, not
+	// *openai.Error, so they need their own classification path.
 	var streamErr *ssestream.StreamError
 	if errors.As(err, &streamErr) {
 		return toProviderErrFromStreamError(streamErr)
@@ -58,41 +53,29 @@ func toProviderErr(err error) error {
 }
 
 // streamErrorEnvelope mirrors the OpenAI-standard error envelope
-// (`{"error": {"code", "message", "param", "type"}}`) that arrives as an
-// in-band SSE event on stream failure.
+// (`{"error": {"code", "message", "type"}}`) that arrives as an in-band
+// SSE event on stream failure.
 type streamErrorEnvelope struct {
 	Error struct {
 		Code    string `json:"code"`
 		Message string `json:"message"`
-		Param   string `json:"param"`
 		Type    string `json:"type"`
 	} `json:"error"`
-}
-
-// retryableStreamErrorTypes are the "type"/"code" values documented as
-// transient, provider-side failures -- the in-stream equivalent of an HTTP
-// 5xx on the initial request.
-var retryableStreamErrorTypes = map[string]bool{
-	"server_error": true,
 }
 
 func toProviderErrFromStreamError(streamErr *ssestream.StreamError) *fantasy.ProviderError {
 	var envelope streamErrorEnvelope
 	_ = json.Unmarshal(streamErr.Event.Data, &envelope) // best-effort; falls back to the raw message on parse failure.
 
-	providerErr := &fantasy.ProviderError{
-		Title:   "stream error",
-		Message: cmp.Or(envelope.Error.Message, streamErr.Message),
-		Cause:   streamErr,
-	}
+	errType := cmp.Or(envelope.Error.Type, envelope.Error.Code)
 
-	if retryableStreamErrorTypes[envelope.Error.Type] || retryableStreamErrorTypes[envelope.Error.Code] {
-		// Synthesize a 5xx so the existing IsRetryable() status-code check
-		// covers this without needing its own special case.
-		providerErr.StatusCode = http.StatusInternalServerError
+	return &fantasy.ProviderError{
+		Title:          "stream error",
+		Message:        cmp.Or(envelope.Error.Message, streamErr.Message),
+		Cause:          streamErr,
+		ResponseBody:   streamErr.Event.Data,
+		TransientError: fantasy.TransientStreamErrorTypes[errType],
 	}
-
-	return providerErr
 }
 
 func parseContextTooLargeError(message string, providerErr *fantasy.ProviderError) {

--- a/providers/openai/error_test.go
+++ b/providers/openai/error_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"charm.land/fantasy"
+	"github.com/openai/openai-go/v3/packages/ssestream"
 )
 
 func TestToProviderErr_WrapsUnexpectedEOF(t *testing.T) {
@@ -59,5 +60,80 @@ func TestToProviderErr_PassesThroughPlainEOF(t *testing.T) {
 	var providerErr *fantasy.ProviderError
 	if errors.As(got, &providerErr) {
 		t.Errorf("toProviderErr wrapped io.EOF as ProviderError; should pass through")
+	}
+}
+
+// Regression test for a real reported bug: a mid-stream in-band SSE error
+// event (the OpenAI-compatible provider's own envelope, not an HTTP-level
+// error) must be classified as retryable when it reports a transient
+// server_error, otherwise it silently skips retry.go entirely instead of
+// just being marked non-retryable.
+func TestToProviderErr_StreamErrorServerErrorIsRetryable(t *testing.T) {
+	t.Parallel()
+
+	streamErr := &ssestream.StreamError{
+		Message: `received error while streaming: {"message":"Streaming response failed","type":"server_error","param":null,"code":"server_error"}`,
+		Event: ssestream.Event{
+			Data: []byte(`{"error":{"message":"Streaming response failed","type":"server_error","param":null,"code":"server_error"}}`),
+		},
+	}
+
+	got := toProviderErr(streamErr)
+
+	var providerErr *fantasy.ProviderError
+	if !errors.As(got, &providerErr) {
+		t.Fatalf("toProviderErr did not wrap StreamError as *fantasy.ProviderError (got %T)", got)
+	}
+	if !providerErr.IsRetryable() {
+		t.Error("server_error stream failure must be retryable so retry.go engages")
+	}
+	if providerErr.Message != "Streaming response failed" {
+		t.Errorf("Message = %q, want the parsed error body message", providerErr.Message)
+	}
+	if !errors.Is(providerErr.Cause, streamErr) {
+		t.Errorf("Cause chain must include the original *ssestream.StreamError")
+	}
+}
+
+func TestToProviderErr_StreamErrorUnknownTypeIsNotRetryable(t *testing.T) {
+	t.Parallel()
+
+	streamErr := &ssestream.StreamError{
+		Message: `received error while streaming: {"message":"bad request","type":"invalid_request_error","param":null,"code":"invalid_request_error"}`,
+		Event: ssestream.Event{
+			Data: []byte(`{"error":{"message":"bad request","type":"invalid_request_error","param":null,"code":"invalid_request_error"}}`),
+		},
+	}
+
+	got := toProviderErr(streamErr)
+
+	var providerErr *fantasy.ProviderError
+	if !errors.As(got, &providerErr) {
+		t.Fatalf("toProviderErr did not wrap StreamError as *fantasy.ProviderError (got %T)", got)
+	}
+	if providerErr.IsRetryable() {
+		t.Error("a non-transient stream error type must not be retryable")
+	}
+}
+
+func TestToProviderErr_StreamErrorMalformedBodyFallsBackToRawMessage(t *testing.T) {
+	t.Parallel()
+
+	streamErr := &ssestream.StreamError{
+		Message: "received error while streaming: not json",
+		Event:   ssestream.Event{Data: []byte("not json")},
+	}
+
+	got := toProviderErr(streamErr)
+
+	var providerErr *fantasy.ProviderError
+	if !errors.As(got, &providerErr) {
+		t.Fatalf("toProviderErr did not wrap StreamError as *fantasy.ProviderError (got %T)", got)
+	}
+	if providerErr.Message != streamErr.Message {
+		t.Errorf("Message = %q, want fallback to raw StreamError.Message %q", providerErr.Message, streamErr.Message)
+	}
+	if providerErr.IsRetryable() {
+		t.Error("unparseable stream error body must not be assumed retryable")
 	}
 }

--- a/providers/openai/error_test.go
+++ b/providers/openai/error_test.go
@@ -63,11 +63,8 @@ func TestToProviderErr_PassesThroughPlainEOF(t *testing.T) {
 	}
 }
 
-// Regression test for a real reported bug: a mid-stream in-band SSE error
-// event (the OpenAI-compatible provider's own envelope, not an HTTP-level
-// error) must be classified as retryable when it reports a transient
-// server_error, otherwise it silently skips retry.go entirely instead of
-// just being marked non-retryable.
+// A mid-stream in-band SSE error event must be classified as retryable when
+// it reports a transient server_error, otherwise it skips retry.go entirely.
 func TestToProviderErr_StreamErrorServerErrorIsRetryable(t *testing.T) {
 	t.Parallel()
 
@@ -87,11 +84,44 @@ func TestToProviderErr_StreamErrorServerErrorIsRetryable(t *testing.T) {
 	if !providerErr.IsRetryable() {
 		t.Error("server_error stream failure must be retryable so retry.go engages")
 	}
+	if !providerErr.TransientError {
+		t.Error("TransientError must be set for a transient stream error")
+	}
+	if providerErr.StatusCode != 0 {
+		t.Errorf("StatusCode = %d, want 0 (no HTTP status was returned)", providerErr.StatusCode)
+	}
 	if providerErr.Message != "Streaming response failed" {
 		t.Errorf("Message = %q, want the parsed error body message", providerErr.Message)
 	}
 	if !errors.Is(providerErr.Cause, streamErr) {
 		t.Errorf("Cause chain must include the original *ssestream.StreamError")
+	}
+}
+
+func TestToProviderErr_StreamErrorTransientTypes(t *testing.T) {
+	t.Parallel()
+
+	for _, errType := range []string{"server_error", "internal_error", "overloaded_error", "api_error", "rate_limit_error"} {
+		t.Run(errType, func(t *testing.T) {
+			t.Parallel()
+
+			streamErr := &ssestream.StreamError{
+				Message: "received error while streaming: ...",
+				Event: ssestream.Event{
+					Data: []byte(`{"error":{"message":"transient","type":"` + errType + `"}}`),
+				},
+			}
+
+			got := toProviderErr(streamErr)
+
+			var providerErr *fantasy.ProviderError
+			if !errors.As(got, &providerErr) {
+				t.Fatalf("toProviderErr did not wrap StreamError (got %T)", got)
+			}
+			if !providerErr.IsRetryable() {
+				t.Errorf("%s stream failure must be retryable", errType)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## What

`toProviderErr` only recognizes `*openai.Error`, the type the SDK uses for errors on the *initial* HTTP response. A mid-stream error delivered as an in-band SSE event (arriving after the response already returned 200 OK) surfaces as a different type, `*ssestream.StreamError`, and openai-go's own doc comment on `Error` says plainly: *"Other errors are not wrapped by this SDK."*

Traced through the actual SDK source (`packages/ssestream/ssestream.go`):

```go
ep := gjson.GetBytes(s.decoder.Event().Data, "error")
if ep.Exists() {
    s.err = &StreamError{
        Message: fmt.Sprintf("received error while streaming: %s", ep.String()),
        ...
    }
    return false
}
```

That produces exactly the error text reported in charmbracelet/crush#3357 (`nemotron 3 ultra free` via OpenCode Zen): `received error while streaming: {"message":"Streaming response failed","type":"server_error",...}`.

Since `*ssestream.StreamError` is not `*openai.Error`, `toProviderErr` falls through to `WrapTransportError`, which only recognizes `io.ErrUnexpectedEOF` and HTTP/2 transport-error fragments. Neither matches. The error passes through unwrapped, never becomes a `*ProviderError`, and `isRetryableError` in `retry.go` has no path that catches it. A transient `server_error` mid-stream never reaches retry classification at all, so exponential backoff never engages.

The same gap exists for Anthropic. The SDK reports mid-stream errors via `fmt.Errorf` with no exported type, so they also fall through unclassified.

## Fix

Add a `TransientError` flag to `ProviderError`. `IsRetryable()` checks it first, before the status-code path. No HTTP 500 happened, so we do not pretend one did.

**OpenAI**: match `*ssestream.StreamError` by type, parse the JSON event data (the standard `{"error":{"code","message","type"}}` envelope), and set `TransientError` when the type names a temporary condition.

**Anthropic**: match the `"received error while streaming:"` message prefix (the SDK gives us nothing typed), parse the nested JSON payload, and classify the same way. All logic stays in the anthropic package.

Transient types covered: `server_error`, `internal_error`, `overloaded_error`, `api_error`, `rate_limit_error`. Permanent types (`invalid_request_error`, `authentication_error`, etc.) are never retried.

## Testing

* OpenAI: retryable `server_error`, all five transient types, non-retryable permanent type, malformed body fallback.
* Anthropic: retryable `overloaded_error`, all five transient types, permanent type not retried, error wrapped by an outer error.
* Integration: updated `TestStream_RequiresMessageStopBeforeFinish` to expect `api_error` as retryable.
* Full suite passes (`go test ./...`).

## Related

Fixes the root cause behind charmbracelet/crush#3357. That issue cannot be fixed crush-side alone since the retry classification gap lives here.

closes charmbracelet/fantasy#323<br>closes [CHARM-1767](https://linear.app/charmland/issue/CHARM-1767/crush-doesnt-auto-retry-hyper-rate-limit-errors)