### PR TITLE
bug(athropic/openai) retry provider overloads reported mid-stream

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,10 +1,13 @@
 package fantasy
 
 import (
+	"cmp"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -51,6 +54,14 @@ type ProviderError struct {
 	// interactive login). It covers auth failures that do not carry an HTTP
 	// 401 status, so a caller-supplied OnAuthRefresh hook still engages.
 	AuthError bool
+
+	// TransientError marks the error as a temporary failure a provider
+	// flagged as worth retrying even though it carries no retryable HTTP
+	// status code. Errors delivered inside an already-successful response,
+	// such as a mid-stream SSE error event, are reported with the status of
+	// the response that carried them, which says nothing about whether a
+	// second attempt can succeed.
+	TransientError bool
 }
 
 func (m *ProviderError) Error() string {
@@ -67,11 +78,15 @@ func (m *ProviderError) Unwrap() error {
 }
 
 // IsRetryable reports whether the error should be retried.
-// It returns true if the underlying cause is io.ErrUnexpectedEOF, if the
-// "x-should-retry" response header evaluates to true, if the HTTP status
-// code indicates a retryable condition (408, 409, 429, or any 5xx), or
-// if the cause is a transient HTTP/2 transport error.
+// It returns true if the error is flagged as transient, if the underlying
+// cause is io.ErrUnexpectedEOF, if the "x-should-retry" response header
+// evaluates to true, if the HTTP status code indicates a retryable
+// condition (408, 409, 429, or any 5xx), or if the cause is a transient
+// HTTP/2 transport error.
 func (m *ProviderError) IsRetryable() bool {
+	if m.TransientError {
+		return true
+	}
 	// We're mostly mimicking OpenAI's Go SDK here:
 	// https://github.com/openai/openai-go/blob/b9d280a37149430982e9dfeed16c41d27d45cfc5/internal/requestconfig/requestconfig.go#L244
 	if errors.Is(m.Cause, io.ErrUnexpectedEOF) {
@@ -195,6 +210,114 @@ func WrapTransportError(err error) error {
 		return NewTransportError(err)
 	default:
 		return err
+	}
+}
+
+// streamEventErrorPrefix is the message prefix the Anthropic and OpenAI Go
+// SDKs use when a stream that opened successfully delivers an `error` event
+// instead of completing. The HTTP response carrying such an event is a 200,
+// so the status code cannot tell us whether a retry is worthwhile; the
+// payload that follows the prefix can.
+const streamEventErrorPrefix = "received error while streaming:"
+
+// transientStreamErrorTypes are provider error `type` values that name a
+// temporary, server-side condition, meaning the same request may well
+// succeed on a later attempt. Anthropic reports shed capacity as
+// overloaded_error and internal faults as api_error; OpenAI-compatible
+// providers use server_error or internal_error. Either family can report a
+// rate limit mid-stream. The list is kept tight so permanent failures
+// (invalid_request_error, authentication_error, and the like) are never
+// retried.
+var transientStreamErrorTypes = []string{
+	"overloaded_error",
+	"api_error",
+	"server_error",
+	"internal_error",
+	"rate_limit_error",
+}
+
+// streamErrorEvent is the payload of an SSE `error` event. Anthropic nests
+// the detail under "error" while the OpenAI SDK hands over the already
+// unwrapped inner object, so both shapes are accepted.
+type streamErrorEvent struct {
+	Type    string            `json:"type"`
+	Message string            `json:"message"`
+	Error   *streamErrorEvent `json:"error"`
+}
+
+// WrapStreamError wraps an error event delivered mid-stream in a
+// ProviderError, marking it transient when the payload names a temporary
+// server-side condition such as Anthropic's overloaded_error. Any other
+// error is returned unchanged.
+//
+// Providers should call this before WrapTransportError: these events ride
+// inside a successful HTTP response, so without classification they reach
+// callers as an opaque, non-retryable blob of JSON and a saturated provider
+// looks like a hard failure.
+func WrapStreamError(err error) error {
+	if err == nil {
+		return nil
+	}
+	msg := err.Error()
+	i := strings.Index(msg, streamEventErrorPrefix)
+	if i == -1 {
+		return err
+	}
+	payload := strings.TrimSpace(msg[i+len(streamEventErrorPrefix):])
+	errType, message := parseStreamErrorEvent(payload)
+	if errType == "" && message == "" {
+		// Nothing recognizable to report: leave the error as it came so no
+		// detail is lost.
+		return err
+	}
+	return &ProviderError{
+		Title:          streamErrorTitle(errType),
+		Message:        cmp.Or(message, payload),
+		Cause:          err,
+		ResponseBody:   []byte(payload),
+		TransientError: slices.Contains(transientStreamErrorTypes, errType),
+	}
+}
+
+// parseStreamErrorEvent extracts the error type and message from an SSE
+// error event payload, unwrapping the nested "error" object when present.
+// A payload that is not JSON, or that is JSON without useful fields, still
+// yields a type when it names a known transient condition, since a provider
+// that mangles its own envelope is exactly the sort we want to retry.
+func parseStreamErrorEvent(payload string) (errType, message string) {
+	var event streamErrorEvent
+	if err := json.Unmarshal([]byte(payload), &event); err == nil {
+		// The outer envelope's type is always "error"; the useful value is
+		// nested when a provider wraps the detail.
+		if event.Error != nil {
+			errType = cmp.Or(event.Error.Type, event.Type)
+			message = cmp.Or(event.Error.Message, event.Message)
+		} else {
+			errType, message = event.Type, event.Message
+		}
+		if errType != "error" {
+			return errType, message
+		}
+	}
+	for _, candidate := range transientStreamErrorTypes {
+		if strings.Contains(payload, candidate) {
+			return candidate, message
+		}
+	}
+	return "", message
+}
+
+// streamErrorTitle renders a provider error type as a human-readable title.
+func streamErrorTitle(errType string) string {
+	switch errType {
+	case "overloaded_error":
+		return "provider overloaded"
+	case "rate_limit_error":
+		return "rate limit exceeded"
+	case "":
+		return "provider stream error"
+	default:
+		return strings.ReplaceAll(errType, "_", " ")
 	}
 }
 

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,6 +1,7 @@
 package fantasy
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -103,6 +104,128 @@ func TestNewTransportErrorWrapped(t *testing.T) {
 	}
 	if !err.IsRetryable() {
 		t.Error("expected wrapped HTTP/2 transport error to be retryable")
+	}
+}
+
+func TestWrapStreamError(t *testing.T) {
+	t.Parallel()
+
+	const prefix = "received error while streaming: "
+
+	tests := []struct {
+		name        string
+		err         error
+		wantWrapped bool
+		wantRetry   bool
+		wantTitle   string
+		wantMessage string
+	}{
+		{
+			name:        "anthropic overloaded",
+			err:         newTestError(prefix + `{"type":"error","error":{"details":null,"type":"overloaded_error","message":"Overloaded"}}`),
+			wantWrapped: true,
+			wantRetry:   true,
+			wantTitle:   "provider overloaded",
+			wantMessage: "Overloaded",
+		},
+		{
+			name:        "anthropic api error",
+			err:         newTestError(prefix + `{"type":"error","error":{"type":"api_error","message":"Internal server error"}}`),
+			wantWrapped: true,
+			wantRetry:   true,
+			wantTitle:   "api error",
+			wantMessage: "Internal server error",
+		},
+		{
+			name:        "openai unwrapped server error",
+			err:         newTestError(prefix + `{"message":"upstream unavailable","type":"server_error","code":null}`),
+			wantWrapped: true,
+			wantRetry:   true,
+			wantTitle:   "server error",
+			wantMessage: "upstream unavailable",
+		},
+		{
+			name:        "rate limit",
+			err:         newTestError(prefix + `{"type":"error","error":{"type":"rate_limit_error","message":"slow down"}}`),
+			wantWrapped: true,
+			wantRetry:   true,
+			wantTitle:   "rate limit exceeded",
+			wantMessage: "slow down",
+		},
+		{
+			name:        "permanent error is wrapped but not retried",
+			err:         newTestError(prefix + `{"type":"error","error":{"type":"invalid_request_error","message":"bad tool schema"}}`),
+			wantWrapped: true,
+			wantRetry:   false,
+			wantTitle:   "invalid request error",
+			wantMessage: "bad tool schema",
+		},
+		{
+			name:        "non-JSON payload naming a transient type",
+			err:         newTestError(prefix + "overloaded_error: capacity exhausted"),
+			wantWrapped: true,
+			wantRetry:   true,
+			wantTitle:   "provider overloaded",
+			wantMessage: "overloaded_error: capacity exhausted",
+		},
+		{
+			name:        "wrapped by an outer error",
+			err:         fmt.Errorf("anthropic: %w", newTestError(prefix+`{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}`)),
+			wantWrapped: true,
+			wantRetry:   true,
+			wantTitle:   "provider overloaded",
+			wantMessage: "Overloaded",
+		},
+		{
+			name: "unrecognizable payload passes through",
+			err:  newTestError(prefix + "{}"),
+		},
+		{
+			name: "unrelated error passes through",
+			err:  newTestError("something went wrong"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := WrapStreamError(tt.err)
+
+			var providerErr *ProviderError
+			if !errors.As(got, &providerErr) {
+				if tt.wantWrapped {
+					t.Fatalf("WrapStreamError(%v) did not wrap as *ProviderError (got %T)", tt.err, got)
+				}
+				if got != tt.err {
+					t.Errorf("WrapStreamError mutated error: got %v, want %v", got, tt.err)
+				}
+				return
+			}
+			if !tt.wantWrapped {
+				t.Fatalf("WrapStreamError(%v) wrapped an error it should have passed through", tt.err)
+			}
+			if providerErr.IsRetryable() != tt.wantRetry {
+				t.Errorf("IsRetryable() = %v, want %v", providerErr.IsRetryable(), tt.wantRetry)
+			}
+			if providerErr.Title != tt.wantTitle {
+				t.Errorf("Title = %q, want %q", providerErr.Title, tt.wantTitle)
+			}
+			if providerErr.Message != tt.wantMessage {
+				t.Errorf("Message = %q, want %q", providerErr.Message, tt.wantMessage)
+			}
+			if !errors.Is(got, tt.err) {
+				t.Error("wrapped error must retain the original error in its chain")
+			}
+		})
+	}
+}
+
+func TestWrapStreamErrorNil(t *testing.T) {
+	t.Parallel()
+
+	if got := WrapStreamError(nil); got != nil {
+		t.Errorf("WrapStreamError(nil) = %v, want nil", got)
 	}
 }
 

--- a/providers/anthropic/anthropic_test.go
+++ b/providers/anthropic/anthropic_test.go
@@ -903,6 +903,7 @@ func TestStream_RequiresMessageStopBeforeFinish(t *testing.T) {
 		chunks         []string
 		wantFinish     bool
 		wantRetryable  bool
+		wantTruncated  bool
 		wantErrContain string
 	}{
 		{
@@ -914,18 +915,31 @@ func TestStream_RequiresMessageStopBeforeFinish(t *testing.T) {
 			name:          "message_stop without stop_reason errors",
 			chunks:        missingStopReasonStream,
 			wantRetryable: true,
+			wantTruncated: true,
 		},
 		{
 			name:          "text stream closed before message_stop errors",
 			chunks:        completeTextStream[:len(completeTextStream)-1],
 			wantRetryable: true,
+			wantTruncated: true,
 		},
 		{
-			name: "provider error event is preserved",
+			// An api_error names a temporary fault on the provider's side,
+			// so it is worth another attempt even though it arrived inside
+			// a response that itself succeeded.
+			name: "provider error event is preserved and retried",
 			chunks: []string{
 				anthropicSSEEvent("error", `{"type":"error","error":{"type":"api_error","message":"stream down"}}`),
 			},
+			wantRetryable:  true,
 			wantErrContain: "stream down",
+		},
+		{
+			name: "permanent error event is not retried",
+			chunks: []string{
+				anthropicSSEEvent("error", `{"type":"error","error":{"type":"invalid_request_error","message":"bad request"}}`),
+			},
+			wantErrContain: "bad request",
 		},
 	}
 
@@ -978,7 +992,9 @@ func TestStream_RequiresMessageStopBeforeFinish(t *testing.T) {
 			if tt.wantRetryable {
 				require.ErrorAs(t, errorParts[0].Error, &providerErr)
 				require.True(t, providerErr.IsRetryable())
-				require.ErrorIs(t, providerErr.Cause, io.ErrUnexpectedEOF)
+				if tt.wantTruncated {
+					require.ErrorIs(t, providerErr.Cause, io.ErrUnexpectedEOF)
+				}
 			} else {
 				require.NotErrorIs(t, errorParts[0].Error, io.ErrUnexpectedEOF)
 				if errors.As(errorParts[0].Error, &providerErr) {
@@ -3236,4 +3252,47 @@ func TestStream_TruncatedWithoutStopReason(t *testing.T) {
 	require.ErrorAs(t, errPart.Error, &providerErr)
 	require.True(t, providerErr.IsRetryable())
 	require.ErrorIs(t, providerErr.Cause, io.ErrUnexpectedEOF)
+}
+
+func TestStream_MidStreamOverloadIsRetryable(t *testing.T) {
+	t.Parallel()
+
+	// A saturated provider sheds load partway through an accepted stream:
+	// the HTTP response is a 200 and the failure arrives as an `error` event.
+	server, _ := newAnthropicStreamingServer([]string{
+		"event: message_start\n",
+		`data: {"type":"message_start","message":{"id":"msg_01","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"usage":{"input_tokens":10,"output_tokens":0}}}` + "\n\n",
+		"event: content_block_start\n",
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}` + "\n\n",
+		"event: content_block_delta\n",
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hel"}}` + "\n\n",
+		"event: error\n",
+		`data: {"type":"error","error":{"details":null,"type":"overloaded_error","message":"Overloaded"}}` + "\n\n",
+	})
+	defer server.Close()
+
+	provider, err := New(WithAPIKey("test-api-key"), WithBaseURL(server.URL))
+	require.NoError(t, err)
+	model, err := provider.LanguageModel(context.Background(), "claude-sonnet-4-20250514")
+	require.NoError(t, err)
+
+	stream, err := model.Stream(context.Background(), fantasy.Call{Prompt: testPrompt()})
+	require.NoError(t, err)
+
+	var errPart *fantasy.StreamPart
+	stream(func(part fantasy.StreamPart) bool {
+		require.NotEqual(t, fantasy.StreamPartTypeFinish, part.Type)
+		if part.Type == fantasy.StreamPartTypeError {
+			p := part
+			errPart = &p
+		}
+		return true
+	})
+	require.NotNil(t, errPart)
+
+	var providerErr *fantasy.ProviderError
+	require.ErrorAs(t, errPart.Error, &providerErr)
+	require.True(t, providerErr.IsRetryable(), "mid-stream overload must be retryable")
+	require.Equal(t, "provider overloaded", providerErr.Title)
+	require.Equal(t, "Overloaded", providerErr.Message)
 }

--- a/providers/anthropic/error.go
+++ b/providers/anthropic/error.go
@@ -48,8 +48,9 @@ func toProviderErr(err error) error {
 			AuthError: true,
 		}
 	}
-	// Wrap transient transport failures so `.IsRetryable()` works.
-	return fantasy.WrapTransportError(err)
+	// Wrap transient failures so `.IsRetryable()` works: error events
+	// delivered mid-stream first, then transport-level failures.
+	return fantasy.WrapTransportError(fantasy.WrapStreamError(err))
 }
 
 func parseContextTooLargeError(message string, providerErr *fantasy.ProviderError) {

--- a/providers/anthropic/error_test.go
+++ b/providers/anthropic/error_test.go
@@ -91,3 +91,23 @@ func TestToProviderErr_FlagsExpiredBedrockCredentials(t *testing.T) {
 		})
 	}
 }
+
+func TestToProviderErr_RetriesMidStreamOverload(t *testing.T) {
+	t.Parallel()
+
+	// Anthropic sheds load by sending an `error` event inside an
+	// already-open stream, so the HTTP response is a 200 and nothing but the
+	// payload marks the failure as temporary.
+	err := errors.New(`received error while streaming: {"type":"error","error":{"details":null,"type":"overloaded_error","message":"Overloaded"}}`)
+
+	var providerErr *fantasy.ProviderError
+	if !errors.As(toProviderErr(err), &providerErr) {
+		t.Fatalf("toProviderErr did not wrap %v as *fantasy.ProviderError", err)
+	}
+	if !providerErr.IsRetryable() {
+		t.Error("a mid-stream overload must be retryable so the step is re-run")
+	}
+	if providerErr.Message != "Overloaded" {
+		t.Errorf("Message = %q, want %q", providerErr.Message, "Overloaded")
+	}
+}

--- a/providers/openai/error.go
+++ b/providers/openai/error.go
@@ -38,8 +38,9 @@ func toProviderErr(err error) error {
 
 		return providerErr
 	}
-	// Wrap transient transport failures so `.IsRetryable()` works.
-	return fantasy.WrapTransportError(err)
+	// Wrap transient failures so `.IsRetryable()` works: error events
+	// delivered mid-stream first, then transport-level failures.
+	return fantasy.WrapTransportError(fantasy.WrapStreamError(err))
 }
 
 func parseContextTooLargeError(message string, providerErr *fantasy.ProviderError) {


### PR DESCRIPTION
When a provider sheds load partway through a stream it sends an error event inside a response that already returned 200, so the status code gives no signal that a second attempt could succeed. Those failures reached callers unclassified and ended the turn instead of backing off and retrying. Temporary conditions are now recognized from the event payload; permanent ones still fail fast.

`internal/agent/agent.go:1146 ` classifies the error to decide what the turn does. Before this fix the overload was a bare `fmt.Errorf` , matching neither  `*fantasy.ProviderError`  nor `*fantasy.Error`  nor  `IsTransportError` , so it falls through to the final else line:

```golang
currentAssistant.AddFinish(message.FinishReasonError, defaultTitle, err.Error())
```

As a result crush will return an error like the following to the user:

```
received error while streaming:
  {"type":"error","error":{"details":null,"type":"overloaded_error","message":"Overloaded"},"request_id":"req_somethingunique"}
```

This is rather transient since it depends on hitting a saturated shared in a provider but results in the request effectively halting since it can never reach `OnRetry`.


tl;dr this is blocking crush from retrying a message that uses streaming.



- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).