### PR TITLE
fix(agent): convert tool panics into failed tool results

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"runtime/debug"
 	"slices"
 	"strings"
 	"sync"
@@ -813,8 +814,11 @@ func (a *agent) executeSingleTool(ctx context.Context, toolMap map[string]AgentT
 		return result, false
 	}
 
-	// Execute the tool
-	toolResult, err := runTool(ctx, ToolCall{
+	// Execute the tool, converting a panic into a failed tool result so a
+	// single misbehaving tool cannot take down the whole process. The panic
+	// value and stack are included so they survive in the transcript even
+	// when stderr is lost.
+	toolResult, err := runToolSafely(ctx, runTool, ToolCall{
 		ID:    toolCall.ToolCallID,
 		Name:  toolCall.ToolName,
 		Input: toolCall.Input,
@@ -852,6 +856,25 @@ func (a *agent) executeSingleTool(ctx context.Context, toolMap map[string]AgentT
 		_ = toolResultCallback(result)
 	}
 	return result, false
+}
+
+// runToolSafely invokes a tool's run function and converts any panic into a
+// failed tool result. Tool implementations run on goroutines spawned by the
+// agent's step processor where an unrecovered panic would crash the entire
+// host process, so this boundary is the last line of defense. The panic
+// value and stack trace are captured in the returned error so they are
+// preserved in the conversation transcript and any persisted logs.
+func runToolSafely(ctx context.Context, runTool func(ctx context.Context, call ToolCall) (ToolResponse, error), call ToolCall) (toolResult ToolResponse, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			stack := debug.Stack()
+			toolResult = NewTextErrorResponse(fmt.Sprintf(
+				"tool %q panicked: %v\n\n%s", call.Name, r, stack,
+			))
+			err = nil
+		}
+	}()
+	return runTool(ctx, call)
 }
 
 // Stream implements Agent.

--- a/agent_test.go
+++ b/agent_test.go
@@ -2722,3 +2722,112 @@ func TestAgent_Generate_StopTurn_NotSet(t *testing.T) {
 	require.Len(t, toolResults, 1)
 	require.False(t, toolResults[0].StopTurn)
 }
+
+func TestAgent_Generate_ToolPanicBecomesFailedResult(t *testing.T) {
+	t.Parallel()
+
+	type PanicInput struct {
+		Value string `json:"value" description:"Test value"`
+	}
+
+	panickingTool := NewAgentTool(
+		"panicking_tool",
+		"A tool that always panics",
+		func(ctx context.Context, input PanicInput, _ ToolCall) (ToolResponse, error) {
+			panic("nil pointer in tool implementation")
+		},
+	)
+
+	model := &mockLanguageModel{
+		generateFunc: func(ctx context.Context, call Call) (*Response, error) {
+			return &Response{
+				Content: []Content{
+					ToolCallContent{
+						ToolCallID: "call-panic",
+						ToolName:   "panicking_tool",
+						Input:      `{"value":"boom"}`,
+					},
+				},
+				Usage:        Usage{InputTokens: 3, OutputTokens: 10, TotalTokens: 13},
+				FinishReason: FinishReasonStop,
+			}, nil
+		},
+	}
+
+	agent := NewAgent(model, WithTools(panickingTool))
+	result, err := agent.Generate(context.Background(), AgentCall{
+		Prompt: "test-input",
+	})
+
+	// The process must survive the panic and surface it as a failed tool
+	// result instead.
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	var toolResults []ToolResultContent
+	for _, content := range result.Response.Content {
+		if toolResult, ok := AsContentType[ToolResultContent](content); ok {
+			toolResults = append(toolResults, toolResult)
+		}
+	}
+	require.Len(t, toolResults, 1)
+	require.Equal(t, "call-panic", toolResults[0].ToolCallID)
+
+	errResult, ok := toolResults[0].Result.(ToolResultOutputContentError)
+	require.True(t, ok, "expected error result, got %T", toolResults[0].Result)
+	require.ErrorContains(t, errResult.Error, "panicking_tool")
+	require.ErrorContains(t, errResult.Error, "nil pointer in tool implementation")
+}
+
+func TestAgent_Generate_ParallelToolPanicBecomesFailedResult(t *testing.T) {
+	t.Parallel()
+
+	type PanicInput struct {
+		Value string `json:"value" description:"Test value"`
+	}
+
+	panickingTool := NewParallelAgentTool(
+		"panicking_parallel_tool",
+		"A parallel tool that always panics",
+		func(ctx context.Context, input PanicInput, _ ToolCall) (ToolResponse, error) {
+			panic("parallel boom")
+		},
+	)
+
+	model := &mockLanguageModel{
+		generateFunc: func(ctx context.Context, call Call) (*Response, error) {
+			return &Response{
+				Content: []Content{
+					ToolCallContent{
+						ToolCallID: "call-parallel-panic",
+						ToolName:   "panicking_parallel_tool",
+						Input:      `{"value":"boom"}`,
+					},
+				},
+				Usage:        Usage{InputTokens: 3, OutputTokens: 10, TotalTokens: 13},
+				FinishReason: FinishReasonStop,
+			}, nil
+		},
+	}
+
+	agent := NewAgent(model, WithTools(panickingTool))
+	result, err := agent.Generate(context.Background(), AgentCall{
+		Prompt: "test-input",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	var toolResults []ToolResultContent
+	for _, content := range result.Response.Content {
+		if toolResult, ok := AsContentType[ToolResultContent](content); ok {
+			toolResults = append(toolResults, toolResult)
+		}
+	}
+	require.Len(t, toolResults, 1)
+
+	errResult, ok := toolResults[0].Result.(ToolResultOutputContentError)
+	require.True(t, ok, "expected error result, got %T", toolResults[0].Result)
+	require.ErrorContains(t, errResult.Error, "panicking_parallel_tool")
+	require.ErrorContains(t, errResult.Error, "parallel boom")
+}


### PR DESCRIPTION
A tool that panics previously took down the entire host process, since tool implementations run on goroutines spawned by the step processor with no recover anywhere between the panic and the goroutine top.

Wrap the tool invocation in executeSingleTool with a recover boundary that converts the panic into a ToolResultOutputContentError containing the panic value and stack trace, so the failure surfaces to the model and is preserved in the transcript even when stderr is lost. Covers both the sequential and parallel dispatch paths and all tool types.