### PR TITLE
fix(providers/openaicompat): forward tool result media to LLM

### DIFF
--- a/providers/openai/language_model_hooks.go
+++ b/providers/openai/language_model_hooks.go
@@ -574,26 +574,10 @@ func DefaultToPrompt(prompt fantasy.Prompt, _, _ string) ([]openai.ChatCompletio
 						continue
 					}
 					// OpenAI Chat Completions tool messages cannot carry image
-					// or audio content directly; the SDK's content union only
-					// accepts text. To keep the tool_call/tool_result pairing
-					// valid while still surfacing the media to vision-capable
-					// models, emit a text tool message with a placeholder (or
-					// any accompanying text) and follow it with a synthetic
-					// user message holding the actual media content part.
-					placeholder := output.Text
-					if placeholder == "" {
-						placeholder = fmt.Sprintf("The tool returned %s content; see the following user message.", output.MediaType)
-					}
-					messages = append(messages, openai.ToolMessage(placeholder, toolResultPart.ToolCallID))
-					mediaPart, mediaWarning, emit := toolResultMediaUserPart(output)
-					if mediaWarning != nil {
-						warnings = append(warnings, *mediaWarning)
-					}
-					if emit {
-						messages = append(messages, openai.UserMessage(
-							[]openai.ChatCompletionContentPartUnionParam{mediaPart},
-						))
-					}
+					// or audio content directly; see ToolResultMediaMessages.
+					mediaMessages, mediaWarnings := ToolResultMediaMessages(output, toolResultPart.ToolCallID)
+					messages = append(messages, mediaMessages...)
+					warnings = append(warnings, mediaWarnings...)
 				default:
 					warnings = append(warnings, fantasy.CallWarning{
 						Type:    fantasy.CallWarningTypeOther,
@@ -604,6 +588,33 @@ func DefaultToPrompt(prompt fantasy.Prompt, _, _ string) ([]openai.ChatCompletio
 		}
 	}
 	return messages, warnings
+}
+
+// ToolResultMediaMessages maps a tool-result media output to the chat
+// completions messages that convey it. OpenAI tool messages can only carry
+// text, so this emits a text tool message (using any accompanying text, or a
+// placeholder describing the media) to keep the tool_call/tool_result pairing
+// valid, followed by a synthetic user message holding the actual image or
+// audio content part so vision- and audio-capable models can see it.
+//
+// Unsupported media types produce only the text tool message plus a warning.
+// This is shared with OpenAI-compatible providers, which face the same
+// constraint.
+func ToolResultMediaMessages(output fantasy.ToolResultOutputContentMedia, toolCallID string) ([]openai.ChatCompletionMessageParamUnion, []fantasy.CallWarning) {
+	placeholder := output.Text
+	if placeholder == "" {
+		placeholder = fmt.Sprintf("The tool returned %s content; see the following user message.", output.MediaType)
+	}
+	messages := []openai.ChatCompletionMessageParamUnion{openai.ToolMessage(placeholder, toolCallID)}
+
+	mediaPart, warning, emit := toolResultMediaUserPart(output)
+	if warning != nil {
+		return messages, []fantasy.CallWarning{*warning}
+	}
+	if emit {
+		messages = append(messages, openai.UserMessage([]openai.ChatCompletionContentPartUnionParam{mediaPart}))
+	}
+	return messages, nil
 }
 
 // toolResultMediaUserPart maps a tool-result media output to an OpenAI chat
@@ -617,19 +628,15 @@ func toolResultMediaUserPart(output fantasy.ToolResultOutputContentMedia) (opena
 			ImageURL: openai.ChatCompletionContentPartImageImageURLParam{URL: data},
 		}
 		return openai.ChatCompletionContentPartUnionParam{OfImageURL: &imageBlock}, nil, true
-	case output.MediaType == "audio/wav":
-		audioBlock := openai.ChatCompletionContentPartInputAudioParam{
-			InputAudio: openai.ChatCompletionContentPartInputAudioInputAudioParam{
-				Data:   output.Data,
-				Format: "wav",
-			},
+	case output.MediaType == "audio/wav", output.MediaType == "audio/mpeg", output.MediaType == "audio/mp3":
+		format := "wav"
+		if output.MediaType != "audio/wav" {
+			format = "mp3"
 		}
-		return openai.ChatCompletionContentPartUnionParam{OfInputAudio: &audioBlock}, nil, true
-	case output.MediaType == "audio/mpeg" || output.MediaType == "audio/mp3":
 		audioBlock := openai.ChatCompletionContentPartInputAudioParam{
 			InputAudio: openai.ChatCompletionContentPartInputAudioInputAudioParam{
 				Data:   output.Data,
-				Format: "mp3",
+				Format: format,
 			},
 		}
 		return openai.ChatCompletionContentPartUnionParam{OfInputAudio: &audioBlock}, nil, true

--- a/providers/openaicompat/language_model_hooks.go
+++ b/providers/openaicompat/language_model_hooks.go
@@ -434,11 +434,82 @@ func ToPromptFunc(prompt fantasy.Prompt, _, _ string) ([]openaisdk.ChatCompletio
 						continue
 					}
 					messages = append(messages, openaisdk.ToolMessage(output.Error.Error(), toolResultPart.ToolCallID))
+				case fantasy.ToolResultContentTypeMedia:
+					output, ok := fantasy.AsToolResultOutputType[fantasy.ToolResultOutputContentMedia](toolResultPart.Output)
+					if !ok {
+						warnings = append(warnings, fantasy.CallWarning{
+							Type:    fantasy.CallWarningTypeOther,
+							Message: "tool result output does not have the right type",
+						})
+						continue
+					}
+					// OpenAI-compatible chat completions tool messages cannot
+					// carry image or audio content directly; the SDK's content
+					// union only accepts text. To keep the tool_call/tool_result
+					// pairing valid while still surfacing the media to
+					// vision-capable models, emit a text tool message with any
+					// accompanying text (or a placeholder) and follow it with a
+					// synthetic user message holding the actual media content
+					// part. This mirrors the behavior of the openai provider.
+					placeholder := output.Text
+					if placeholder == "" {
+						placeholder = fmt.Sprintf("The tool returned %s content; see the following user message.", output.MediaType)
+					}
+					messages = append(messages, openaisdk.ToolMessage(placeholder, toolResultPart.ToolCallID))
+					mediaPart, mediaWarning, emit := toolResultMediaUserPart(output)
+					if mediaWarning != nil {
+						warnings = append(warnings, *mediaWarning)
+					}
+					if emit {
+						messages = append(messages, openaisdk.UserMessage(
+							[]openaisdk.ChatCompletionContentPartUnionParam{mediaPart},
+						))
+					}
+				default:
+					warnings = append(warnings, fantasy.CallWarning{
+						Type:    fantasy.CallWarningTypeOther,
+						Message: fmt.Sprintf("tool result output type %q not supported", toolResultPart.Output.GetType()),
+					})
 				}
 			}
 		}
 	}
 	return messages, warnings
+}
+
+// toolResultMediaUserPart maps a tool-result media output to an OpenAI chat
+// completions user content part. It returns the content part, an optional
+// warning, and whether the caller should emit the returned part.
+func toolResultMediaUserPart(output fantasy.ToolResultOutputContentMedia) (openaisdk.ChatCompletionContentPartUnionParam, *fantasy.CallWarning, bool) {
+	switch {
+	case strings.HasPrefix(output.MediaType, "image/"):
+		data := "data:" + output.MediaType + ";base64," + output.Data
+		imageBlock := openaisdk.ChatCompletionContentPartImageParam{
+			ImageURL: openaisdk.ChatCompletionContentPartImageImageURLParam{URL: data},
+		}
+		return openaisdk.ChatCompletionContentPartUnionParam{OfImageURL: &imageBlock}, nil, true
+	case output.MediaType == "audio/wav":
+		audioBlock := openaisdk.ChatCompletionContentPartInputAudioParam{
+			InputAudio: openaisdk.ChatCompletionContentPartInputAudioInputAudioParam{
+				Data:   output.Data,
+				Format: "wav",
+			},
+		}
+		return openaisdk.ChatCompletionContentPartUnionParam{OfInputAudio: &audioBlock}, nil, true
+	case output.MediaType == "audio/mpeg" || output.MediaType == "audio/mp3":
+		audioBlock := openaisdk.ChatCompletionContentPartInputAudioParam{
+			InputAudio: openaisdk.ChatCompletionContentPartInputAudioInputAudioParam{
+				Data:   output.Data,
+				Format: "mp3",
+			},
+		}
+		return openaisdk.ChatCompletionContentPartUnionParam{OfInputAudio: &audioBlock}, nil, true
+	default:
+		return openaisdk.ChatCompletionContentPartUnionParam{}, &fantasy.CallWarning{
+			Type:    fantasy.CallWarningTypeOther,
+			Message: fmt.Sprintf("tool result media type %s not supported, sending text placeholder only", output.MediaType),
+		}, false
+	}
 }
 
 func hasVisibleCompatUserContent(content []openaisdk.ChatCompletionContentPartUnionParam) bool {

--- a/providers/openaicompat/language_model_hooks.go
+++ b/providers/openaicompat/language_model_hooks.go
@@ -445,26 +445,12 @@ func ToPromptFunc(prompt fantasy.Prompt, _, _ string) ([]openaisdk.ChatCompletio
 					}
 					// OpenAI-compatible chat completions tool messages cannot
 					// carry image or audio content directly; the SDK's content
-					// union only accepts text. To keep the tool_call/tool_result
-					// pairing valid while still surfacing the media to
-					// vision-capable models, emit a text tool message with any
-					// accompanying text (or a placeholder) and follow it with a
-					// synthetic user message holding the actual media content
-					// part. This mirrors the behavior of the openai provider.
-					placeholder := output.Text
-					if placeholder == "" {
-						placeholder = fmt.Sprintf("The tool returned %s content; see the following user message.", output.MediaType)
-					}
-					messages = append(messages, openaisdk.ToolMessage(placeholder, toolResultPart.ToolCallID))
-					mediaPart, mediaWarning, emit := toolResultMediaUserPart(output)
-					if mediaWarning != nil {
-						warnings = append(warnings, *mediaWarning)
-					}
-					if emit {
-						messages = append(messages, openaisdk.UserMessage(
-							[]openaisdk.ChatCompletionContentPartUnionParam{mediaPart},
-						))
-					}
+					// union only accepts text. Reuse the openai provider's
+					// helper, which emits a text tool message plus a synthetic
+					// user message holding the media.
+					mediaMessages, mediaWarnings := openai.ToolResultMediaMessages(output, toolResultPart.ToolCallID)
+					messages = append(messages, mediaMessages...)
+					warnings = append(warnings, mediaWarnings...)
 				default:
 					warnings = append(warnings, fantasy.CallWarning{
 						Type:    fantasy.CallWarningTypeOther,
@@ -480,37 +466,6 @@ func ToPromptFunc(prompt fantasy.Prompt, _, _ string) ([]openaisdk.ChatCompletio
 // toolResultMediaUserPart maps a tool-result media output to an OpenAI chat
 // completions user content part. It returns the content part, an optional
 // warning, and whether the caller should emit the returned part.
-func toolResultMediaUserPart(output fantasy.ToolResultOutputContentMedia) (openaisdk.ChatCompletionContentPartUnionParam, *fantasy.CallWarning, bool) {
-	switch {
-	case strings.HasPrefix(output.MediaType, "image/"):
-		data := "data:" + output.MediaType + ";base64," + output.Data
-		imageBlock := openaisdk.ChatCompletionContentPartImageParam{
-			ImageURL: openaisdk.ChatCompletionContentPartImageImageURLParam{URL: data},
-		}
-		return openaisdk.ChatCompletionContentPartUnionParam{OfImageURL: &imageBlock}, nil, true
-	case output.MediaType == "audio/wav":
-		audioBlock := openaisdk.ChatCompletionContentPartInputAudioParam{
-			InputAudio: openaisdk.ChatCompletionContentPartInputAudioInputAudioParam{
-				Data:   output.Data,
-				Format: "wav",
-			},
-		}
-		return openaisdk.ChatCompletionContentPartUnionParam{OfInputAudio: &audioBlock}, nil, true
-	case output.MediaType == "audio/mpeg" || output.MediaType == "audio/mp3":
-		audioBlock := openaisdk.ChatCompletionContentPartInputAudioParam{
-			InputAudio: openaisdk.ChatCompletionContentPartInputAudioInputAudioParam{
-				Data:   output.Data,
-				Format: "mp3",
-			},
-		}
-		return openaisdk.ChatCompletionContentPartUnionParam{OfInputAudio: &audioBlock}, nil, true
-	default:
-		return openaisdk.ChatCompletionContentPartUnionParam{}, &fantasy.CallWarning{
-			Type:    fantasy.CallWarningTypeOther,
-			Message: fmt.Sprintf("tool result media type %s not supported, sending text placeholder only", output.MediaType),
-		}, false
-	}
-}
 
 func hasVisibleCompatUserContent(content []openaisdk.ChatCompletionContentPartUnionParam) bool {
 	for _, part := range content {

--- a/providers/openaicompat/tool_result_media_test.go
+++ b/providers/openaicompat/tool_result_media_test.go
@@ -1,0 +1,209 @@
+package openaicompat
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"charm.land/fantasy"
+	"github.com/stretchr/testify/require"
+)
+
+// Tool messages in the OpenAI Chat Completions API cannot carry image or audio
+// content directly — the SDK's content union only accepts text. When a tool
+// returns media, ToPromptFunc must still emit a text tool message so the
+// tool_call/tool_result pairing stays valid, and attach the media to a
+// synthetic follow-up user message so vision- and audio-capable models can see
+// it.
+//
+// These tests guard against regressions of charmbracelet/fantasy#208, where
+// the openaicompat provider silently dropped tool results carrying
+// ToolResultOutputContentMedia.
+
+func TestToPromptFunc_MediaToolResult_ImagePNG(t *testing.T) {
+	t.Parallel()
+
+	imageData := base64.StdEncoding.EncodeToString([]byte{0, 1, 2, 3})
+	prompt := fantasy.Prompt{
+		{
+			Role: fantasy.MessageRoleAssistant,
+			Content: []fantasy.MessagePart{
+				fantasy.ToolCallPart{ToolCallID: "img-1", ToolName: "view", Input: "{}"},
+			},
+		},
+		{
+			Role: fantasy.MessageRoleTool,
+			Content: []fantasy.MessagePart{
+				fantasy.ToolResultPart{
+					ToolCallID: "img-1",
+					Output: fantasy.ToolResultOutputContentMedia{
+						Data:      imageData,
+						MediaType: "image/png",
+					},
+				},
+			},
+		},
+	}
+
+	messages, warnings := ToPromptFunc(prompt, "", "")
+
+	require.Empty(t, warnings)
+	// Assistant tool call + text tool message + synthetic user image message.
+	require.Len(t, messages, 3)
+
+	toolMsg := messages[1].OfTool
+	require.NotNil(t, toolMsg)
+	require.Equal(t, "img-1", toolMsg.ToolCallID)
+	require.Contains(t, toolMsg.Content.OfString.Value, "image/png")
+
+	userMsg := messages[2].OfUser
+	require.NotNil(t, userMsg)
+	require.Len(t, userMsg.Content.OfArrayOfContentParts, 1)
+	imagePart := userMsg.Content.OfArrayOfContentParts[0].OfImageURL
+	require.NotNil(t, imagePart)
+	require.Equal(t, "data:image/png;base64,"+imageData, imagePart.ImageURL.URL)
+}
+
+func TestToPromptFunc_MediaToolResult_PrefersAccompanyingText(t *testing.T) {
+	t.Parallel()
+
+	imageData := base64.StdEncoding.EncodeToString([]byte{9, 9, 9})
+	prompt := fantasy.Prompt{
+		{
+			Role: fantasy.MessageRoleAssistant,
+			Content: []fantasy.MessagePart{
+				fantasy.ToolCallPart{ToolCallID: "img-2", ToolName: "view", Input: "{}"},
+			},
+		},
+		{
+			Role: fantasy.MessageRoleTool,
+			Content: []fantasy.MessagePart{
+				fantasy.ToolResultPart{
+					ToolCallID: "img-2",
+					Output: fantasy.ToolResultOutputContentMedia{
+						Data:      imageData,
+						MediaType: "image/jpeg",
+						Text:      "Screenshot of the blockquote element.",
+					},
+				},
+			},
+		},
+	}
+
+	messages, warnings := ToPromptFunc(prompt, "", "")
+
+	require.Empty(t, warnings)
+	require.Len(t, messages, 3)
+	require.Equal(t, "Screenshot of the blockquote element.", messages[1].OfTool.Content.OfString.Value)
+}
+
+func TestToPromptFunc_MediaToolResult_AudioWAV(t *testing.T) {
+	t.Parallel()
+
+	audio := base64.StdEncoding.EncodeToString([]byte("fake-wav-bytes"))
+	prompt := fantasy.Prompt{
+		{
+			Role: fantasy.MessageRoleAssistant,
+			Content: []fantasy.MessagePart{
+				fantasy.ToolCallPart{ToolCallID: "audio-1", ToolName: "record", Input: "{}"},
+			},
+		},
+		{
+			Role: fantasy.MessageRoleTool,
+			Content: []fantasy.MessagePart{
+				fantasy.ToolResultPart{
+					ToolCallID: "audio-1",
+					Output: fantasy.ToolResultOutputContentMedia{
+						Data:      audio,
+						MediaType: "audio/wav",
+					},
+				},
+			},
+		},
+	}
+
+	messages, warnings := ToPromptFunc(prompt, "", "")
+
+	require.Empty(t, warnings)
+	require.Len(t, messages, 3)
+	require.NotNil(t, messages[1].OfTool)
+	userMsg := messages[2].OfUser
+	require.NotNil(t, userMsg)
+	require.Len(t, userMsg.Content.OfArrayOfContentParts, 1)
+	audioPart := userMsg.Content.OfArrayOfContentParts[0].OfInputAudio
+	require.NotNil(t, audioPart)
+	require.Equal(t, audio, audioPart.InputAudio.Data)
+	require.Equal(t, "wav", audioPart.InputAudio.Format)
+}
+
+func TestToPromptFunc_MediaToolResult_AudioMP3(t *testing.T) {
+	t.Parallel()
+
+	audio := base64.StdEncoding.EncodeToString([]byte("fake-mp3-bytes"))
+	prompt := fantasy.Prompt{
+		{
+			Role: fantasy.MessageRoleAssistant,
+			Content: []fantasy.MessagePart{
+				fantasy.ToolCallPart{ToolCallID: "audio-2", ToolName: "record", Input: "{}"},
+			},
+		},
+		{
+			Role: fantasy.MessageRoleTool,
+			Content: []fantasy.MessagePart{
+				fantasy.ToolResultPart{
+					ToolCallID: "audio-2",
+					Output: fantasy.ToolResultOutputContentMedia{
+						Data:      audio,
+						MediaType: "audio/mpeg",
+					},
+				},
+			},
+		},
+	}
+
+	messages, warnings := ToPromptFunc(prompt, "", "")
+
+	require.Empty(t, warnings)
+	require.Len(t, messages, 3)
+	require.NotNil(t, messages[1].OfTool)
+	userMsg := messages[2].OfUser
+	require.NotNil(t, userMsg)
+	require.Len(t, userMsg.Content.OfArrayOfContentParts, 1)
+	audioPart := userMsg.Content.OfArrayOfContentParts[0].OfInputAudio
+	require.NotNil(t, audioPart)
+	require.Equal(t, audio, audioPart.InputAudio.Data)
+	require.Equal(t, "mp3", audioPart.InputAudio.Format)
+}
+
+func TestToPromptFunc_MediaToolResult_UnsupportedMediaType(t *testing.T) {
+	t.Parallel()
+
+	prompt := fantasy.Prompt{
+		{
+			Role: fantasy.MessageRoleAssistant,
+			Content: []fantasy.MessagePart{
+				fantasy.ToolCallPart{ToolCallID: "vid-1", ToolName: "record", Input: "{}"},
+			},
+		},
+		{
+			Role: fantasy.MessageRoleTool,
+			Content: []fantasy.MessagePart{
+				fantasy.ToolResultPart{
+					ToolCallID: "vid-1",
+					Output: fantasy.ToolResultOutputContentMedia{
+						Data:      "AAAA",
+						MediaType: "video/mp4",
+					},
+				},
+			},
+		},
+	}
+
+	messages, warnings := ToPromptFunc(prompt, "", "")
+
+	// Assistant tool call + text tool message, but no synthetic user image.
+	require.Len(t, messages, 2)
+	require.NotNil(t, messages[1].OfTool)
+	require.Equal(t, "vid-1", messages[1].OfTool.ToolCallID)
+	require.Len(t, warnings, 1)
+	require.Contains(t, warnings[0].Message, "video/mp4")
+}


### PR DESCRIPTION
closes https://github.com/charmbracelet/fantasy/pull/241

clean copy of that pr plus a rebase to not conflict with main and exporting `ToolResultMediaMessages` to deduplicate checks