### PR TITLE
fix(anthropic): use adaptive thinking for modern Claude models

### DIFF
--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -50,12 +50,16 @@ func thinkingDisplay(providerOptions *ProviderOptions, modelID string) (Thinking
 }
 
 func defaultsToAdaptiveThinking(model string) bool {
-	model = strings.ToLower(strings.TrimSpace(model))
-	return strings.Contains(model, "claude-mythos-preview")
+	// Mythos-class models enable adaptive thinking by default even when the
+	// caller does not pass thinking options.
+	return isMythosClassModel(model)
 }
 
 func requiresAdaptiveThinking(model string) bool {
-	return defaultsToAdaptiveThinking(model) || defaultsToOmittedOpusThinkingDisplay(model)
+	// When a caller enables thinking via budget_tokens, upgrade to adaptive
+	// for every modern Claude model that rejects thinking.type=enabled.
+	// Older Claude families keep the legacy enabled+budget path.
+	return isClaudeModel(model) && !isLegacyManualThinkingClaudeModel(model)
 }
 
 func setThinkingDisplay(param interface{ SetExtraFields(map[string]any) }, display ThinkingDisplay) {
@@ -63,25 +67,96 @@ func setThinkingDisplay(param interface{ SetExtraFields(map[string]any) }, displ
 }
 
 func defaultsToOmittedThinkingDisplay(model string) bool {
-	model = strings.ToLower(strings.TrimSpace(model))
-	return defaultsToAdaptiveThinking(model) || defaultsToOmittedOpusThinkingDisplay(model)
+	// Models whose API default for thinking.display is "omitted" need an
+	// explicit summarized display so callers still receive reasoning text.
+	return isMythosClassModel(model) || isModernOpusFamilyModel(model)
 }
 
-func defaultsToOmittedOpusThinkingDisplay(model string) bool {
-	_, suffix, ok := strings.Cut(model, "claude-opus-4-")
-	if !ok {
-		return false
+func isClaudeModel(model string) bool {
+	return strings.Contains(strings.ToLower(strings.TrimSpace(model)), "claude")
+}
+
+func isMythosClassModel(model string) bool {
+	m := strings.ToLower(strings.TrimSpace(model))
+	return strings.Contains(m, "claude-mythos") || strings.Contains(m, "claude-fable")
+}
+
+// isModernOpusFamilyModel reports whether model is an Opus release that uses
+// the modern adaptive thinking contract (Opus 4.7+ and Opus 5+).
+func isModernOpusFamilyModel(model string) bool {
+	m := strings.ToLower(strings.TrimSpace(model))
+
+	// Named major lines: claude-opus-5, claude-opus-5-..., bedrock variants.
+	if _, after, ok := cutAfter(m, "claude-opus-"); ok {
+		if major, ok := leadingInt(after); ok && major >= 5 {
+			return true
+		}
 	}
 
-	versionEnd := 0
-	for versionEnd < len(suffix) && suffix[versionEnd] >= '0' && suffix[versionEnd] <= '9' {
-		versionEnd++
+	// Numbered 4.x minors: claude-opus-4-7, claude-opus-4.8, bedrock forms.
+	if _, after, ok := cutAfter(m, "claude-opus-4-"); ok {
+		if minor, ok := leadingInt(after); ok && minor >= 7 && minor <= 99 {
+			// Reject date-stamped original GA IDs like claude-opus-4-20250514
+			// (leading int would be 20250514, already excluded by <= 99).
+			return true
+		}
 	}
-	if versionEnd == 0 || versionEnd > 2 {
+	if _, after, ok := cutAfter(m, "claude-opus-4."); ok {
+		if minor, ok := leadingInt(after); ok && minor >= 7 && minor <= 99 {
+			return true
+		}
+	}
+	return false
+}
+
+// isLegacyManualThinkingClaudeModel reports Claude families that still require
+// thinking.type=enabled + budget_tokens. Unknown/future Claude models default
+// to the modern adaptive contract.
+func isLegacyManualThinkingClaudeModel(model string) bool {
+	m := strings.ToLower(strings.TrimSpace(model))
+	if !strings.Contains(m, "claude") {
 		return false
 	}
-	minor, err := strconv.Atoi(suffix[:versionEnd])
-	return err == nil && minor >= 7
+	// Anything modern is not legacy.
+	if isMythosClassModel(m) || isModernOpusFamilyModel(m) {
+		return false
+	}
+	// Claude 5+ non-opus lines (sonnet-5, etc.).
+	for _, family := range []string{"claude-sonnet-", "claude-haiku-"} {
+		if _, after, ok := cutAfter(m, family); ok {
+			if major, ok := leadingInt(after); ok && major >= 5 {
+				return false
+			}
+		}
+	}
+	// Adaptive-capable 4.6 family.
+	if strings.Contains(m, "claude-opus-4-6") || strings.Contains(m, "claude-opus-4.6") ||
+		strings.Contains(m, "claude-sonnet-4-6") || strings.Contains(m, "claude-sonnet-4.6") {
+		return false
+	}
+	// Remaining Claude IDs (3.x, 4.0/4.1/4.5, bare opus/sonnet-4, haiku-4.5)
+	// still use manual budget thinking when thinking is requested.
+	return true
+}
+
+func cutAfter(s, sep string) (string, string, bool) {
+	i := strings.Index(s, sep)
+	if i < 0 {
+		return "", "", false
+	}
+	return s[:i], s[i+len(sep):], true
+}
+
+func leadingInt(s string) (int, bool) {
+	end := 0
+	for end < len(s) && s[end] >= '0' && s[end] <= '9' {
+		end++
+	}
+	if end == 0 {
+		return 0, false
+	}
+	n, err := strconv.Atoi(s[:end])
+	return n, err == nil
 }
 
 // buildRequestOptions constructs the common request options shared

--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -87,21 +87,21 @@ func isModernOpusFamilyModel(model string) bool {
 	m := strings.ToLower(strings.TrimSpace(model))
 
 	// Named major lines: claude-opus-5, claude-opus-5-..., bedrock variants.
-	if _, after, ok := cutAfter(m, "claude-opus-"); ok {
+	if after, ok := cutAfter(m, "claude-opus-"); ok {
 		if major, ok := leadingInt(after); ok && major >= 5 {
 			return true
 		}
 	}
 
 	// Numbered 4.x minors: claude-opus-4-7, claude-opus-4.8, bedrock forms.
-	if _, after, ok := cutAfter(m, "claude-opus-4-"); ok {
+	if after, ok := cutAfter(m, "claude-opus-4-"); ok {
 		if minor, ok := leadingInt(after); ok && minor >= 7 && minor <= 99 {
 			// Reject date-stamped original GA IDs like claude-opus-4-20250514
 			// (leading int would be 20250514, already excluded by <= 99).
 			return true
 		}
 	}
-	if _, after, ok := cutAfter(m, "claude-opus-4."); ok {
+	if after, ok := cutAfter(m, "claude-opus-4."); ok {
 		if minor, ok := leadingInt(after); ok && minor >= 7 && minor <= 99 {
 			return true
 		}
@@ -123,7 +123,7 @@ func isLegacyManualThinkingClaudeModel(model string) bool {
 	}
 	// Claude 5+ non-opus lines (sonnet-5, etc.).
 	for _, family := range []string{"claude-sonnet-", "claude-haiku-"} {
-		if _, after, ok := cutAfter(m, family); ok {
+		if after, ok := cutAfter(m, family); ok {
 			if major, ok := leadingInt(after); ok && major >= 5 {
 				return false
 			}
@@ -139,12 +139,12 @@ func isLegacyManualThinkingClaudeModel(model string) bool {
 	return true
 }
 
-func cutAfter(s, sep string) (string, string, bool) {
+func cutAfter(s, sep string) (string, bool) {
 	i := strings.Index(s, sep)
 	if i < 0 {
-		return "", "", false
+		return "", false
 	}
-	return s[:i], s[i+len(sep):], true
+	return s[i+len(sep):], true
 }
 
 func leadingInt(s string) (int, bool) {

--- a/providers/anthropic/anthropic_test.go
+++ b/providers/anthropic/anthropic_test.go
@@ -744,6 +744,46 @@ func TestGenerate_SendsThinkingDisplay(t *testing.T) {
 			wantDisplay: "summarized",
 		},
 		{
+			name:  "opus 5 upgrades budget thinking to adaptive",
+			model: "claude-opus-5",
+			options: func() *ProviderOptions {
+				return &ProviderOptions{Thinking: &ThinkingProviderOption{BudgetTokens: 2048}}
+			},
+			wantType:    "adaptive",
+			wantDisplay: "summarized",
+		},
+		{
+			name:  "fable upgrades budget thinking to adaptive",
+			model: "claude-fable-5",
+			options: func() *ProviderOptions {
+				return &ProviderOptions{Thinking: &ThinkingProviderOption{BudgetTokens: 2048}}
+			},
+			wantType:    "adaptive",
+			wantDisplay: "summarized",
+		},
+		{
+			name:  "sonnet 5 upgrades budget thinking to adaptive",
+			model: "claude-sonnet-5",
+			options: func() *ProviderOptions {
+				display := ThinkingDisplaySummarized
+				return &ProviderOptions{
+					Thinking:        &ThinkingProviderOption{BudgetTokens: 2048},
+					ThinkingDisplay: &display,
+				}
+			},
+			wantType:    "adaptive",
+			wantDisplay: "summarized",
+		},
+		{
+			name:  "legacy sonnet 4.5 keeps enabled budget thinking",
+			model: "claude-sonnet-4-5-20250929",
+			options: func() *ProviderOptions {
+				return &ProviderOptions{Thinking: &ThinkingProviderOption{BudgetTokens: 2048}}
+			},
+			wantType:   "enabled",
+			wantBudget: 2048,
+		},
+		{
 			name:  "older opus models keep provider default",
 			model: "claude-opus-4-6-20260101",
 			options: func() *ProviderOptions {
@@ -826,14 +866,18 @@ func TestDefaultsToOmittedThinkingDisplay(t *testing.T) {
 		{name: "opus 4.7 alias", model: "claude-opus-4-7", want: true},
 		{name: "opus 4.7", model: "claude-opus-4-7-20260101", want: true},
 		{name: "opus 4.10", model: "claude-opus-4-10-20260101", want: true},
+		{name: "opus 5", model: "claude-opus-5", want: true},
+		{name: "bedrock opus 5", model: "us.anthropic.claude-opus-5-v1", want: true},
 		{name: "bedrock opus 4.8 alias", model: "us.anthropic.claude-opus-4-8-v1", want: true},
 		{name: "bedrock opus 4.8", model: "us.anthropic.claude-opus-4-8-20260101-v1:0", want: true},
 		{name: "mythos preview", model: "claude-mythos-preview", want: true},
 		{name: "bedrock mythos preview", model: "anthropic.claude-mythos-preview", want: true},
+		{name: "fable", model: "claude-fable-5", want: true},
 		{name: "opus 4.6", model: "claude-opus-4-6-20260101", want: false},
 		{name: "opus 4 date only", model: "claude-opus-4-20250514", want: false},
 		{name: "bedrock opus 4 date only", model: "us.anthropic.claude-opus-4-20250514-v1:0", want: false},
 		{name: "sonnet", model: "claude-sonnet-4-20250514", want: false},
+		{name: "sonnet 5", model: "claude-sonnet-5", want: false},
 		{name: "no minor", model: "claude-opus-4", want: false},
 	}
 
@@ -842,6 +886,41 @@ func TestDefaultsToOmittedThinkingDisplay(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			require.Equal(t, tt.want, defaultsToOmittedThinkingDisplay(tt.model))
+		})
+	}
+}
+
+func TestRequiresAdaptiveThinking(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		model string
+		want  bool
+	}{
+		{name: "opus 5", model: "claude-opus-5", want: true},
+		{name: "fable 5", model: "claude-fable-5", want: true},
+		{name: "sonnet 5", model: "claude-sonnet-5", want: true},
+		{name: "opus 4.8", model: "claude-opus-4-8", want: true},
+		{name: "opus 4.7", model: "claude-opus-4-7", want: true},
+		{name: "opus 4.6", model: "claude-opus-4-6", want: true},
+		{name: "sonnet 4.6", model: "claude-sonnet-4-6", want: true},
+		{name: "mythos", model: "claude-mythos-preview", want: true},
+		{name: "bedrock opus 5", model: "us.anthropic.claude-opus-5-v1:0", want: true},
+		{name: "opus 4.5", model: "claude-opus-4-5", want: false},
+		{name: "sonnet 4.5", model: "claude-sonnet-4-5", want: false},
+		{name: "haiku 4.5", model: "claude-haiku-4-5", want: false},
+		{name: "opus 4 date", model: "claude-opus-4-20250514", want: false},
+		{name: "bare opus 4", model: "claude-opus-4", want: false},
+		{name: "claude 3.5", model: "claude-3-5-sonnet", want: false},
+		{name: "non claude", model: "minimax-m2", want: false},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, requiresAdaptiveThinking(tt.model), tt.model)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Claude models such as `claude-opus-5` and `claude-fable-5` reject the legacy extended-thinking shape:

```json
{"thinking":{"type":"enabled","budget_tokens":2048}}
```

with:

> `"thinking.type.enabled" is not supported for this model. Use "thinking.type.adaptive" and "output_config.effort" to control thinking behavior.`

Fantasy already upgrades budget thinking to adaptive for `claude-opus-4-N` where `N >= 7` and for mythos preview IDs, but bare modern IDs like `claude-opus-5` / `claude-fable-5` still took the legacy path.

This change:

- Treats **modern Claude models** (4.6+, Opus 5+, Fable/Mythos, Sonnet 5+) as requiring adaptive thinking when budget thinking is requested
- Keeps the **legacy enabled+budget** path for older Claude families (3.x, 4.0/4.1/4.5, bare `claude-opus-4`, etc.)
- Extends the summarized `thinking.display` default to Opus 5+ and Fable/Mythos so reasoning text remains visible

## Test plan

- [x] `go test ./providers/anthropic/ -count=1`
- [x] New cases: Opus 5 / Fable / Sonnet 5 budget → adaptive
- [x] Legacy Sonnet 4.5 budget → enabled
- [x] Helper coverage via `TestRequiresAdaptiveThinking` / updated display defaults

## Notes

Checked current `main` and open PRs — no existing PR covers this adaptive-thinking model detection gap.