### PR TITLE
fix: stop adding empty reasoning fields

### DIFF
--- a/providers/openaicompat/language_model_hooks.go
+++ b/providers/openaicompat/language_model_hooks.go
@@ -80,9 +80,9 @@ func ExtraContentFunc(choice openaisdk.ChatCompletionChoice) []fantasy.Content {
 	if err != nil {
 		return content
 	}
-	if rc := reasoningData.GetReasoningContent(); rc != "" {
+	if hasReasoningField(choice.Message.RawJSON()) {
 		content = append(content, fantasy.ReasoningContent{
-			Text: rc,
+			Text: reasoningData.GetReasoningContent(),
 		})
 	}
 	return content
@@ -136,7 +136,7 @@ func StreamExtraFunc(chunk openaisdk.ChatCompletionChunk, yield func(fantasy.Str
 				Delta: reasoningContent,
 			})
 		}
-		if rc := reasoningData.GetReasoningContent(); rc != "" {
+		if rc := reasoningData.GetReasoningContent(); rc != "" || hasReasoningField(choice.Delta.RawJSON()) {
 			if !reasoningStarted {
 				ctx[reasoningStartedCtx] = true
 			}
@@ -159,7 +159,6 @@ func StreamExtraFunc(chunk openaisdk.ChatCompletionChunk, yield func(fantasy.Str
 func ToPromptFunc(prompt fantasy.Prompt, _, _ string) ([]openaisdk.ChatCompletionMessageParamUnion, []fantasy.CallWarning) {
 	var messages []openaisdk.ChatCompletionMessageParamUnion
 	var warnings []fantasy.CallWarning
-	hasReasoning := false
 
 	for _, msg := range prompt {
 		switch msg.Role {
@@ -373,6 +372,7 @@ func ToPromptFunc(prompt fantasy.Prompt, _, _ string) ([]openaisdk.ChatCompletio
 				Role: "assistant",
 			}
 			var reasoningText string
+			reasoningPresent := false
 			for _, c := range msg.Content {
 				switch c.GetType() {
 				case fantasy.ContentTypeText:
@@ -406,7 +406,7 @@ func ToPromptFunc(prompt fantasy.Prompt, _, _ string) ([]openaisdk.ChatCompletio
 						continue
 					}
 					reasoningText = reasoningPart.Text
-					hasReasoning = true
+					reasoningPresent = true
 				case fantasy.ContentTypeToolCall:
 					toolCallPart, ok := fantasy.AsContentType[fantasy.ToolCallPart](c)
 					if !ok {
@@ -429,10 +429,12 @@ func ToPromptFunc(prompt fantasy.Prompt, _, _ string) ([]openaisdk.ChatCompletio
 						})
 				}
 			}
-			// Add reasoning_content field if present, or if thinking is enabled
-			// and the message has tool calls (some providers like Kimi require
-			// reasoning_content on all assistant messages when thinking is enabled).
-			if reasoningText != "" || (hasReasoning && len(assistantMsg.ToolCalls) > 0) {
+			// Add reasoning_content field if the message carries a reasoning
+			// part, even when its text is empty: presence must mirror what the
+			// model emitted so resubmitted history stays byte-stable for prefix
+			// caching. Providers like Kimi require the field on assistant
+			// tool-call messages when thinking is enabled.
+			if reasoningPresent {
 				assistantMsg.SetExtraFields(map[string]any{
 					"reasoning_content": reasoningText,
 				})

--- a/providers/openaicompat/openaicompat_test.go
+++ b/providers/openaicompat/openaicompat_test.go
@@ -347,12 +347,14 @@ func TestToPromptFunc_DropsEmptyMessages(t *testing.T) {
 		require.Empty(t, warnings)
 	})
 
-	t.Run("should add empty reasoning_content to tool call messages when thinking is enabled", func(t *testing.T) {
+	t.Run("should add reasoning_content to tool call messages only when the message itself reasoned", func(t *testing.T) {
 		t.Parallel()
 
-		// When thinking is enabled (reasoning parts exist in history),
-		// tool call messages without their own reasoning must still include
-		// reasoning_content. Providers like Kimi require it.
+		// reasoning_content presence is decided per message from its own
+		// reasoning part, never from conversation history. This keeps
+		// resubmitted history byte-stable for prefix caches (see #330),
+		// while still emitting the (possibly empty) field that providers
+		// like Kimi require on assistant tool-call messages.
 		prompt := fantasy.Prompt{
 			{
 				Role: fantasy.MessageRoleUser,
@@ -392,13 +394,56 @@ func TestToPromptFunc_DropsEmptyMessages(t *testing.T) {
 		require.Empty(t, warnings)
 		require.Len(t, messages, 4)
 
-		// Tool call message must have reasoning_content (empty) since
-		// thinking is enabled in this conversation
+		// The reasoning turn keeps its reasoning_content.
+		reasoningMsg := messages[1].OfAssistant
+		require.NotNil(t, reasoningMsg)
+		rc, ok := reasoningMsg.ExtraFields()["reasoning_content"]
+		require.True(t, ok)
+		require.Equal(t, "Simple math.", rc)
+
+		// The tool-call message has no reasoning part of its own, so no
+		// reasoning_content is manufactured for it.
 		msg := messages[3].OfAssistant
 		require.NotNil(t, msg)
-		extraFields := msg.ExtraFields()
-		reasoningContent, hasReasoning := extraFields["reasoning_content"]
-		require.True(t, hasReasoning, "reasoning_content must be present on tool call messages when thinking is enabled")
+		_, hasReasoning := msg.ExtraFields()["reasoning_content"]
+		require.False(t, hasReasoning, "reasoning_content must not be synthesized from history (see #330)")
+	})
+
+	t.Run("should emit empty reasoning_content when the tool call message has an empty reasoning part", func(t *testing.T) {
+		t.Parallel()
+
+		// A present-but-empty reasoning part on the message itself still
+		// emits reasoning_content: "" (present), satisfying providers like
+		// Kimi while staying byte-stable.
+		prompt := fantasy.Prompt{
+			{
+				Role: fantasy.MessageRoleUser,
+				Content: []fantasy.MessagePart{
+					fantasy.TextPart{Text: "Run it"},
+				},
+			},
+			{
+				Role: fantasy.MessageRoleAssistant,
+				Content: []fantasy.MessagePart{
+					fantasy.ReasoningPart{Text: ""},
+					fantasy.ToolCallPart{
+						ToolCallID: "call_1",
+						ToolName:   "execute",
+						Input:      `{"command":"echo 4"}`,
+					},
+				},
+			},
+		}
+
+		messages, warnings := ToPromptFunc(prompt, "", "")
+
+		require.Empty(t, warnings)
+		require.Len(t, messages, 2)
+
+		msg := messages[1].OfAssistant
+		require.NotNil(t, msg)
+		reasoningContent, hasReasoning := msg.ExtraFields()["reasoning_content"]
+		require.True(t, hasReasoning, "present-but-empty reasoning part must emit reasoning_content")
 		require.Equal(t, "", reasoningContent)
 	})
 

--- a/providers/openaicompat/provider_options.go
+++ b/providers/openaicompat/provider_options.go
@@ -54,6 +54,20 @@ func (r ReasoningData) GetReasoningContent() string {
 	return r.Reasoning
 }
 
+// hasReasoningField reports whether raw JSON contains a reasoning field
+// ("reasoning_content" or "reasoning"), even when its value is empty.
+func hasReasoningField(rawJSON string) bool {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(rawJSON), &fields); err != nil {
+		return false
+	}
+	if _, ok := fields["reasoning_content"]; ok {
+		return true
+	}
+	_, ok := fields["reasoning"]
+	return ok
+}
+
 // Options implements the ProviderOptions interface.
 func (*ProviderOptions) Options() {}
 


### PR DESCRIPTION
When converting conversation history into an API request, the provider was adding an empty `reasoning_content` field to every assistant tool-call message that came after any message with reasoning — even when that message never had reasoning of its own.

Now the field is only included when the assistant message actually has reasoning content, and empty reasoning from the model is preserved as-is instead of being dropped and later re-created.

Fixes charmbracelet/fantasy#330