### PR TITLE
fix(agent): report unknown tool parameters

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -1212,13 +1212,35 @@ func (a *agent) validateToolCall(toolCall ToolCallContent, availableTools []Agen
 		return fmt.Errorf("invalid JSON input: %w", err)
 	}
 
-	// Basic schema validation (check required fields)
+	// Basic schema validation (check required and unknown fields)
 	// TODO: more robust schema validation using JSON Schema or similar
 	toolInfo := tool.Info()
+	validationErrors := make([]string, 0, 2) //nolint:mnd
 	for _, required := range toolInfo.Required {
 		if _, exists := input[required]; !exists {
-			return fmt.Errorf("missing required parameter: %s", required)
+			validationErrors = append(validationErrors, fmt.Sprintf("missing required parameter: %s", required))
+			break
 		}
+	}
+
+	unknown := make([]string, 0)
+	_, acceptsAdditionalParameters := toolInfo.Parameters["*"]
+	if len(toolInfo.Parameters) > 0 && !acceptsAdditionalParameters {
+		for parameter := range input {
+			if _, exists := toolInfo.Parameters[parameter]; !exists {
+				unknown = append(unknown, parameter)
+			}
+		}
+	}
+	slices.Sort(unknown)
+	if len(unknown) == 1 {
+		validationErrors = append(validationErrors, fmt.Sprintf("unknown additional parameter: %s", unknown[0]))
+	} else if len(unknown) > 1 {
+		validationErrors = append(validationErrors, fmt.Sprintf("unknown additional parameters: %s", strings.Join(unknown, ", ")))
+	}
+
+	if len(validationErrors) > 0 {
+		return errors.New(strings.Join(validationErrors, "; "))
 	}
 	return nil
 }

--- a/agent_test.go
+++ b/agent_test.go
@@ -68,6 +68,94 @@ func (m *mockLanguageModel) Generate(ctx context.Context, call Call) (*Response,
 	}, nil
 }
 
+func TestValidateToolCallParameters(t *testing.T) {
+	t.Parallel()
+
+	tool := &mockTool{
+		name: "edit",
+		parameters: map[string]any{
+			"old_string": map[string]any{"type": "string"},
+		},
+		required: []string{"old_string"},
+	}
+	a := &agent{}
+
+	tests := []struct {
+		name  string
+		input string
+		err   string
+	}{
+		{
+			name:  "valid",
+			input: `{"old_string":"before"}`,
+		},
+		{
+			name:  "missing required and unknown",
+			input: `{"old-string":"before"}`,
+			err:   "missing required parameter: old_string; unknown additional parameter: old-string",
+		},
+		{
+			name:  "unknown only",
+			input: `{"old_string":"before","extra":true}`,
+			err:   "unknown additional parameter: extra",
+		},
+		{
+			name:  "unknown parameters are sorted",
+			input: `{"old_string":"before","z":1,"a":2}`,
+			err:   "unknown additional parameters: a, z",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := a.validateToolCall(ToolCallContent{
+				ToolName: "edit",
+				Input:    tt.input,
+			}, []AgentTool{tool}, nil)
+			if tt.err == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.EqualError(t, err, tt.err)
+		})
+	}
+}
+
+func TestValidateToolCallAllowsOpenParameters(t *testing.T) {
+	t.Parallel()
+
+	dynamicMapTool := NewAgentTool("dynamic", "dynamic input", func(context.Context, map[string]string, ToolCall) (ToolResponse, error) {
+		return NewTextResponse("ok"), nil
+	})
+	tests := []struct {
+		name string
+		tool AgentTool
+	}{
+		{
+			name: "dynamic map parameters",
+			tool: dynamicMapTool,
+		},
+		{
+			name: "unspecified parameters",
+			tool: &mockTool{name: "dynamic"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := (&agent{}).validateToolCall(ToolCallContent{
+				ToolName: "dynamic",
+				Input:    `{"arbitrary":"value"}`,
+			}, []AgentTool{tt.tool}, nil)
+			require.NoError(t, err)
+		})
+	}
+}
+
 func (m *mockLanguageModel) Stream(ctx context.Context, call Call) (StreamResponse, error) {
 	if m.streamFunc != nil {
 		return m.streamFunc(ctx, call)


### PR DESCRIPTION
## Summary

- validate top-level tool input keys against explicitly declared parameters
- report an unknown parameter together with a missing required parameter
- preserve open input semantics for dynamic `map[string]T` tools and tools without a declared schema
- sort unknown parameter names for deterministic errors
- add focused coverage for fixed, dynamic, missing, and unknown parameter combinations

This makes errors such as `old-string` versus `old_string` explicit so models can correct malformed tool calls without rejecting legitimate dynamic tool inputs.

## Tests

- `go test ./... -count=1 -timeout=30m`
- `go vet ./...`
- `golangci-lint run`

Fixes #304
