### PR TITLE
feat(agent): allow disabling tools per call

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -172,6 +172,7 @@ type AgentCall struct {
 	PresencePenalty  *float64    `json:"presence_penalty"`
 	FrequencyPenalty *float64    `json:"frequency_penalty"`
 	ActiveTools      []string    `json:"active_tools"`
+	DisableAllTools  bool        `json:"disable_all_tools"`
 	ToolChoice       *ToolChoice `json:"tool_choice"`
 	Headers          map[string]string
 	ProviderOptions  ProviderOptions
@@ -281,6 +282,7 @@ type AgentStreamCall struct {
 	PresencePenalty  *float64    `json:"presence_penalty"`
 	FrequencyPenalty *float64    `json:"frequency_penalty"`
 	ActiveTools      []string    `json:"active_tools"`
+	DisableAllTools  bool        `json:"disable_all_tools"`
 	ToolChoice       *ToolChoice `json:"tool_choice"`
 	Headers          map[string]string
 	ProviderOptions  ProviderOptions
@@ -455,7 +457,7 @@ func (a *agent) Generate(ctx context.Context, opts AgentCall) (*AgentResult, err
 		if opts.ToolChoice != nil {
 			stepToolChoice = *opts.ToolChoice
 		}
-		disableAllTools := false
+		disableAllTools := opts.DisableAllTools
 		stepTools := a.settings.tools
 		if opts.PrepareStep != nil {
 			updatedCtx, prepared, err := opts.PrepareStep(ctx, PrepareStepFunctionOptions{
@@ -486,7 +488,7 @@ func (a *agent) Generate(ctx context.Context, opts AgentCall) (*AgentResult, err
 			if len(prepared.ActiveTools) > 0 {
 				stepActiveTools = prepared.ActiveTools
 			}
-			disableAllTools = prepared.DisableAllTools
+			disableAllTools = disableAllTools || prepared.DisableAllTools
 			if prepared.Tools != nil {
 				stepTools = prepared.Tools
 			}
@@ -891,6 +893,7 @@ func (a *agent) Stream(ctx context.Context, opts AgentStreamCall) (*AgentResult,
 		PresencePenalty:  opts.PresencePenalty,
 		FrequencyPenalty: opts.FrequencyPenalty,
 		ActiveTools:      opts.ActiveTools,
+		DisableAllTools:  opts.DisableAllTools,
 		ToolChoice:       opts.ToolChoice,
 		Headers:          opts.Headers,
 		ProviderOptions:  opts.ProviderOptions,
@@ -928,7 +931,7 @@ func (a *agent) Stream(ctx context.Context, opts AgentStreamCall) (*AgentResult,
 		if call.ToolChoice != nil {
 			stepToolChoice = *call.ToolChoice
 		}
-		disableAllTools := false
+		disableAllTools := call.DisableAllTools
 		stepTools := a.settings.tools
 		// Apply step preparation if provided
 		if call.PrepareStep != nil {
@@ -959,7 +962,7 @@ func (a *agent) Stream(ctx context.Context, opts AgentStreamCall) (*AgentResult,
 			if len(prepared.ActiveTools) > 0 {
 				stepActiveTools = prepared.ActiveTools
 			}
-			disableAllTools = prepared.DisableAllTools
+			disableAllTools = disableAllTools || prepared.DisableAllTools
 			if prepared.Tools != nil {
 				stepTools = prepared.Tools
 			}

--- a/agent_stream_test.go
+++ b/agent_stream_test.go
@@ -238,6 +238,35 @@ func TestStreamingAgentCallbacks(t *testing.T) {
 	require.False(t, callbacks["OnToolResult"], "OnToolResult should not be called without actual tool results")
 }
 
+func TestAgent_Stream_DisableAllTools(t *testing.T) {
+	t.Parallel()
+
+	model := &mockLanguageModel{
+		streamFunc: func(ctx context.Context, call Call) (StreamResponse, error) {
+			require.Empty(t, call.Tools)
+			return func(yield func(StreamPart) bool) {
+				yield(StreamPart{
+					Type:         StreamPartTypeFinish,
+					FinishReason: FinishReasonStop,
+				})
+			}, nil
+		},
+	}
+	tool := &EchoTool{}
+	providerTool := ProviderDefinedTool{ID: "provider.web_search", Name: "web_search"}
+	agent := NewAgent(model, WithTools(tool), WithProviderDefinedTools(providerTool))
+
+	result, err := agent.Stream(context.Background(), AgentStreamCall{
+		Prompt:          "test-input",
+		DisableAllTools: true,
+		PrepareStep: func(ctx context.Context, _ PrepareStepFunctionOptions) (context.Context, PrepareStepResult, error) {
+			return ctx, PrepareStepResult{}, nil
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+}
+
 // TestStreamingAgentWithTools tests streaming agent with tool calls (mirrors TS test patterns)
 func TestStreamingAgentWithTools(t *testing.T) {
 	t.Parallel()

--- a/agent_test.go
+++ b/agent_test.go
@@ -754,6 +754,33 @@ func TestAgent_Generate_OptionsActiveTools_WithProviderDefinedTools(t *testing.T
 	require.NotNil(t, result)
 }
 
+func TestAgent_Generate_DisableAllTools(t *testing.T) {
+	t.Parallel()
+
+	model := &mockLanguageModel{
+		generateFunc: func(ctx context.Context, call Call) (*Response, error) {
+			require.Empty(t, call.Tools)
+			return &Response{
+				Content:      ResponseContent{TextContent{Text: "Response"}},
+				FinishReason: FinishReasonStop,
+			}, nil
+		},
+	}
+	tool := &mockTool{name: "tool1", description: "Test tool"}
+	providerTool := ProviderDefinedTool{ID: "provider.web_search", Name: "web_search"}
+	agent := NewAgent(model, WithTools(tool), WithProviderDefinedTools(providerTool))
+
+	result, err := agent.Generate(context.Background(), AgentCall{
+		Prompt:          "test-input",
+		DisableAllTools: true,
+		PrepareStep: func(ctx context.Context, _ PrepareStepFunctionOptions) (context.Context, PrepareStepResult, error) {
+			return ctx, PrepareStepResult{}, nil
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+}
+
 func TestResponseContent_Getters(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- add `DisableAllTools` to `AgentCall` and `AgentStreamCall`
- apply the option for every step in both generate and stream paths
- preserve call-level disabling when `PrepareStep` returns its zero-value result
- cover regular and provider-defined tools in both execution modes

This lets callers make a tool-free request with an agent that is otherwise configured with tools, without adding a `PrepareStep` callback solely to disable them.

## Tests

- `go test ./... -count=1 -timeout=30m`
- `go vet ./...`
- `golangci-lint run`

Fixes #235
