### PR TITLE
chore: standardize Go version to 1.26.6

### DIFF
--- a/examples/go.mod
+++ b/examples/go.mod
@@ -1,6 +1,6 @@
 module charm.land/fantasy/examples
 
-go 1.26.1
+go 1.26.6
 
 replace charm.land/fantasy => ../
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module charm.land/fantasy
 
-go 1.26.1
+go 1.26.6
 
 require (
 	charm.land/x/vcr v0.1.1


### PR DESCRIPTION
## Summary
- standardize the maintained root module on Go 1.26.6
- standardize the maintained examples module on Go 1.26.6

The standalone `examples/structured-outputs` sample remains at Go 1.25.2 as an intentionally separate compatibility example.

## Verification
- `GOMAXPROCS=2 go test ./... -count=1`
- `cd examples && GOMAXPROCS=2 go test ./... -count=1`